### PR TITLE
Remove 386 goarch from GoReleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,6 @@ builds:
       - openbsd
       - windows
     goarch:
-      - 386
       - amd64
       - arm
 archives:


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint-ruleset-azurerm/runs/682847716

In i386, the upper limit of the automatically generated number exceeds the range of integer.

To work around this issue, remove 386 support once. If anyone wants support on a 32-bit OS, we'll look into it, but I believe it will never be needed.