### PR TITLE
Added input parameters for generation paths. Also debugging configs for VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/tools/apispec-rule-gen/",
+      "env": {},
+      "args": [
+        "-base-path=.",
+        "-rules-path=../../rules",
+        "-docs-path=../../docs"
+      ]
+    }
+  ]
+}

--- a/tools/README.md
+++ b/tools/README.md
@@ -8,6 +8,34 @@ This script generate rules from [azure-rest-api-specs](https://github.com/Azure/
 
 The correspondence between API definitions and Terraform attributes is defined in the [mapping files](apispec-rule-gen/mappings). It also includes Terraform's schema file to check for invalid mappings.
 
+### Debugging with VS Code
+
+* Open the root of this repo in [VS Code](https://code.visualstudio.com/).
+* Install the [Go Extension for VS Code](https://github.com/golang/vscode-go) via the Extensions icon on the left hand menu.
+* Press F5 to start the debugger or click on 'Run' -> 'Start Debugging'
+
+The launch.json file provides default values for the tool base path, rule generation target path and doc generation target path. You can override these if needed.
+
+```json
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/tools/apispec-rule-gen/",
+      "env": {},
+      "args": [
+        "-base-path=.",
+        "-rules-path=../../rules",
+        "-docs-path=../../docs"
+      ]
+    }
+  ]
+}
+```
+
 ### Update azure-rest-api-specs
 
 ```console

--- a/tools/apispec-rule-gen/schema.go
+++ b/tools/apispec-rule-gen/schema.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 )
 
@@ -32,7 +33,10 @@ type attribute struct {
 }
 
 func loadProviderSchema() provider {
-	src, err := ioutil.ReadFile("apispec-rule-gen/schema/schema.json")
+	schemaPath := getFullPath("schema/schema.json")
+	fmt.Println(schemaPath)
+	src, err := ioutil.ReadFile(schemaPath)
+
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This change includes the parametrization of paths for output and templates. The default values if the parameters are not passed in are the same as previous values so that it is backwards compatible and the generation program will run without any input parameters.

Included also is a launch.json file with overrides for parameters. This allows easy debugging from within VS Code, including support for setting breakpoints.

This was tested on WSL2 - running ubuntu.

