### PR TITLE
Added support for linting Azure VM UserNames

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/tools/apispec-rule-gen/",
+      "env": {},
+      "args": [
+        "-base-path=.",
+        "-rules-path=../../rules",
+        "-docs-path=../../docs"
+      ]
+    }
+  ]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,12 +6,12 @@ This documentation describes a list of rules available by enabling this ruleset.
 
 |Rule|Enabled by default|
 | --- | --- |
-|[azurerm_linux_virtual_machine_admin_username](rules/azurerm_linux_virtual_machine_admin_username.md)|✔|
+|[azurerm_linux_virtual_machine_invalid_admin_username](rules/azurerm_linux_virtual_machine_invalid_admin_username.md)|✔|
 |[azurerm_linux_virtual_machine_invalid_size](rules/azurerm_linux_virtual_machine_invalid_size.md)|✔|
 |[azurerm_linux_virtual_machine_scale_set_invalid_sku](rules/azurerm_linux_virtual_machine_scale_set_invalid_sku.md)|✔|
-|[azurerm_virtual_machine_admin_username](rules/azurerm_linux_virtual_machine_admin_username.md)|✔|
+|[azurerm_virtual_machine_invalid_admin_username](rules/azurerm_virtual_machine_invalid_admin_username.md)|✔|
 |[azurerm_virtual_machine_invalid_vm_size](rules/azurerm_virtual_machine_invalid_vm_size.md)|✔|
-|[azurerm_windows_virtual_machine_admin_username](rules/azurerm_windows_virtual_machine_admin_username.md)|✔|
+|[azurerm_windows_virtual_machine_invalid_admin_username](rules/azurerm_windows_virtual_machine_invalid_admin_username.md)|✔|
 |[azurerm_windows_virtual_machine_invalid_size](rules/azurerm_windows_virtual_machine_invalid_size.md)|✔|
 |[azurerm_windows_virtual_machine_scale_set_invalid_sku](rules/azurerm_windows_virtual_machine_scale_set_invalid_sku.md)|✔|
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,9 +6,12 @@ This documentation describes a list of rules available by enabling this ruleset.
 
 |Rule|Enabled by default|
 | --- | --- |
+|[azurerm_linux_virtual_machine_admin_username](rules/azurerm_linux_virtual_machine_admin_username.md)|✔|
 |[azurerm_linux_virtual_machine_invalid_size](rules/azurerm_linux_virtual_machine_invalid_size.md)|✔|
 |[azurerm_linux_virtual_machine_scale_set_invalid_sku](rules/azurerm_linux_virtual_machine_scale_set_invalid_sku.md)|✔|
+|[azurerm_virtual_machine_admin_username](rules/azurerm_linux_virtual_machine_admin_username.md)|✔|
 |[azurerm_virtual_machine_invalid_vm_size](rules/azurerm_virtual_machine_invalid_vm_size.md)|✔|
+|[azurerm_windows_virtual_machine_admin_username](rules/azurerm_windows_virtual_machine_admin_username.md)|✔|
 |[azurerm_windows_virtual_machine_invalid_size](rules/azurerm_windows_virtual_machine_invalid_size.md)|✔|
 |[azurerm_windows_virtual_machine_scale_set_invalid_sku](rules/azurerm_windows_virtual_machine_scale_set_invalid_sku.md)|✔|
 

--- a/docs/rules/azurerm_linux_virtual_machine_invalid_admin_username.md
+++ b/docs/rules/azurerm_linux_virtual_machine_invalid_admin_username.md
@@ -1,0 +1,75 @@
+# azurerm_linux_virtual_machine_invalid_size
+
+Warns about admin user values that appear to be invalid based on https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-username-requirements-when-creating-a-vm
+
+Invalid Admin Usernames include:
+- azureuser
+- 1
+- 123
+- a
+- actuser
+- adm
+- admin
+- admin1
+- admin2
+- administrator
+- aspnet
+- backup
+- console
+- david
+- guest
+- john
+- owner
+- root
+- server
+- sql
+- support_388945a0
+- support
+- sys
+- test
+- test1
+- test2
+- test3
+- user
+- user1
+- user2
+- user3
+- user4
+- user5
+- video
+
+Username validation is lower cased to ensure that linting rules are applied regardless of casing for the admin_username field.
+
+Note, the value "AzureUser" will result in an linting error even though is not explicitly mentioned in the Virtual Machine docs. This is because of it's common and default usage, it becomes an easy to guess username. It's recommended to select a unique user name.
+
+## Example
+
+```hcl
+resource "azurerm_linux_virtual_machine" "test" {
+	admin_username = "root"
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Error: "root" is not a valid Linux VM Admin username (azurerm_linux_virtual_machine_invalid_admin_username)
+
+  on main.tf line 43:
+  43:   admin_username      = "root"
+
+Reference: https://github.com/terraform-linters/tflint-ruleset-azurerm/blob/v0.5.1/docs/rules/azurerm_linux_virtual_machine_invalid_admin_username.md
+```
+
+## Why
+
+Requests containing not allowed usernames will return an error when calling the API by `terraform apply`.
+
+## How to Fix
+
+Replace the not allowed usernames with a valid value that is not in the list above.
+
+## Source
+
+https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-username-requirements-when-creating-a-vm

--- a/docs/rules/azurerm_virtual_machine_invalid_admin_username.md
+++ b/docs/rules/azurerm_virtual_machine_invalid_admin_username.md
@@ -1,0 +1,78 @@
+# azurerm_linux_virtual_machine_invalid_size
+
+Warns about admin user values that appear to be invalid based on https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-username-requirements-when-creating-a-vm
+
+Invalid Admin Usernames include:
+- azureuser
+- 1
+- 123
+- a
+- actuser
+- adm
+- admin
+- admin1
+- admin2
+- administrator
+- aspnet
+- backup
+- console
+- david
+- guest
+- john
+- owner
+- root
+- server
+- sql
+- support_388945a0
+- support
+- sys
+- test
+- test1
+- test2
+- test3
+- user
+- user1
+- user2
+- user3
+- user4
+- user5
+- video
+
+Username validation is lower cased to ensure that linting rules are applied regardless of casing for the admin_username field.
+
+Note, the value "AzureUser" will result in an linting error even though is not explicitly mentioned in the Virtual Machine docs. This is because of it's common and default usage, it becomes an easy to guess username. It's recommended to select a unique user name.
+
+## Example
+
+```hcl
+resource "azurerm_virtual_machine" "test" {
+	os_profile {
+		admin_username = "123"
+	}
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Error: "123" is not a valid VM Admin username (azurerm_virtual_machine_invalid_admin_username)
+
+  on main.tf line 75:
+  75:     admin_username = "123"
+
+Reference: https://github.com/terraform-linters/tflint-ruleset-azurerm/blob/v0.5.1/docs/rules/azurerm_virtual_machine_invalid_admin_username.md
+
+```
+
+## Why
+
+Requests containing not allowed usernames will return an error when calling the API by `terraform apply`.
+
+## How to Fix
+
+Replace the not allowed usernames with a valid value that is not in the list above.
+
+## Source
+
+https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-username-requirements-when-creating-a-vm

--- a/docs/rules/azurerm_virtual_machine_invalid_admin_username.md
+++ b/docs/rules/azurerm_virtual_machine_invalid_admin_username.md
@@ -1,4 +1,4 @@
-# azurerm_linux_virtual_machine_invalid_size
+# azurerm_virtual_machine_invalid_admin_username
 
 Warns about admin user values that appear to be invalid based on https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-username-requirements-when-creating-a-vm
 

--- a/docs/rules/azurerm_windows_virtual_machine_invalid_admin_username.md
+++ b/docs/rules/azurerm_windows_virtual_machine_invalid_admin_username.md
@@ -1,0 +1,71 @@
+# azurerm_windows_virtual_machine_invalid_admin_username
+
+Warns about admin user values that appear to be invalid based on https://docs.microsoft.com/en-us/azure/virtual-machines/windows/faq#what-are-the-username-requirements-when-creating-a-vm
+
+Invalid Admin Usernames include:
+- azureuser
+- 1
+- 123
+- a
+- actuser
+- adm
+- admin
+- admin1
+- admin2
+- administrator
+- aspnet
+- backup
+- console
+- david
+- guest
+- john
+- owner
+- root
+- server
+- sql
+- support_388945a0
+- support
+- sys
+- test
+- test1
+- test2
+- test3
+- user
+- user1
+- user2
+
+Username validation is lower cased to ensure that linting rules are applied regardless of casing for the admin_username field.
+
+Note, the value "AzureUser" will result in an linting error even though is not explicitly mentioned in the Virtual Machine docs. This is because of it's common and default usage, it becomes an easy to guess username. It's recommended to select a unique user name.
+
+## Example
+
+```hcl
+resource "azurerm_windows_virtual_machine_invalid_admin_username" "test" {
+	admin_username = "root"
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Error: "root" is not a valid Windows VM Admin username (azurerm_windows_virtual_machine_invalid_admin_username)
+
+  on main.tf line 43:
+  43:   admin_username      = "root"
+
+Reference: https://github.com/terraform-linters/tflint-ruleset-azurerm/blob/v0.5.1/docs/rules/azurerm_windows_virtual_machine_invalid_admin_username.md
+```
+
+## Why
+
+Requests containing not allowed usernames will return an error when calling the API by `terraform apply`.
+
+## How to Fix
+
+Replace the not allowed usernames with a valid value that is not in the list above.
+
+## Source
+
+https://docs.microsoft.com/en-us/azure/virtual-machines/windows/faq#what-are-the-username-requirements-when-creating-a-vm

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/terraform-linters/tflint-ruleset-azurerm
 go 1.15
 
 require (
+	github.com/golang/mock v1.1.1
 	github.com/google/go-cmp v0.5.2
 	github.com/hashicorp/hcl/v2 v2.6.0
 	github.com/terraform-linters/tflint-plugin-sdk v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,7 @@ github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=

--- a/rules/azurerm_linux_virtual_machine_invalid_admin_username.go
+++ b/rules/azurerm_linux_virtual_machine_invalid_admin_username.go
@@ -51,7 +51,7 @@ func (r *AzurermLinuxVirtualMachineInvalidAdminUserNameRule) Check(runner tflint
 		err := runner.EvaluateExpr(attribute.Expr, &val)
 
 		return runner.EnsureNoError(err, func() error {
-			valid, err := isVlidVMAdminUserNames(val)
+			valid, err := isValidVMAdminUserNames(val)
 			if err != nil {
 				panic(err)
 			}

--- a/rules/azurerm_linux_virtual_machine_invalid_admin_username.go
+++ b/rules/azurerm_linux_virtual_machine_invalid_admin_username.go
@@ -1,5 +1,7 @@
 package rules
 
+// Please see: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-username-requirements-when-creating-a-vm
+
 import (
 	"fmt"
 	"strings"
@@ -16,8 +18,7 @@ type AzurermLinuxVirtualMachineInvalidAdminUserNameRule struct {
 	enum          []string
 }
 
-// Please see: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-username-requirements-when-creating-a-vm
-// NewAzurermLinuxVirtualMachineInvalidSizeRule returns new rule with default attributes
+// NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule returns new rule with default attributes
 func NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule() *AzurermLinuxVirtualMachineInvalidAdminUserNameRule {
 	return &AzurermLinuxVirtualMachineInvalidAdminUserNameRule{
 		resourceType:  "azurerm_linux_virtual_machine",

--- a/rules/azurerm_linux_virtual_machine_invalid_admin_username.go
+++ b/rules/azurerm_linux_virtual_machine_invalid_admin_username.go
@@ -4,7 +4,6 @@ package rules
 
 import (
 	"fmt"
-	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
@@ -15,7 +14,6 @@ import (
 type AzurermLinuxVirtualMachineInvalidAdminUserNameRule struct {
 	resourceType  string
 	attributeName string
-	enum          []string
 }
 
 // NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule returns new rule with default attributes
@@ -23,42 +21,6 @@ func NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule() *AzurermLinuxVirtua
 	return &AzurermLinuxVirtualMachineInvalidAdminUserNameRule{
 		resourceType:  "azurerm_linux_virtual_machine",
 		attributeName: "admin_username",
-		enum: []string{
-			"azureuser",
-			"1",
-			"123",
-			"a",
-			"actuser",
-			"adm",
-			"admin",
-			"admin1",
-			"admin2",
-			"administrator",
-			"aspnet",
-			"backup",
-			"console",
-			"david",
-			"guest",
-			"john",
-			"owner",
-			"root",
-			"server",
-			"sql",
-			"support_388945a0",
-			"support",
-			"sys",
-			"test",
-			"test1",
-			"test2",
-			"test3",
-			"user",
-			"user1",
-			"user2",
-			"user3",
-			"user4",
-			"user5",
-			"video",
-		},
 	}
 }
 
@@ -89,21 +51,20 @@ func (r *AzurermLinuxVirtualMachineInvalidAdminUserNameRule) Check(runner tflint
 		err := runner.EvaluateExpr(attribute.Expr, &val)
 
 		return runner.EnsureNoError(err, func() error {
-			found := false
-			val = strings.ToLower(val)
-			for _, item := range r.enum {
-				if strings.ToLower(item) == val {
-					found = true
-				}
+			valid, err := isVlidVMAdminUserNames(val)
+			if err != nil {
+				panic(err)
 			}
-			if found {
-				runner.EmitIssueOnExpr(
-					r,
-					fmt.Sprintf(`"%s" is not a valid Linux VM Admin username`, val),
-					attribute.Expr,
-				)
+
+			if valid {
+				return nil
 			}
-			return nil
+
+			return runner.EmitIssueOnExpr(
+				r,
+				fmt.Sprintf(`"%s" is not a valid Linux VM Admin username`, val),
+				attribute.Expr,
+			)
 		})
 	})
 }

--- a/rules/azurerm_linux_virtual_machine_invalid_admin_username.go
+++ b/rules/azurerm_linux_virtual_machine_invalid_admin_username.go
@@ -51,7 +51,7 @@ func (r *AzurermLinuxVirtualMachineInvalidAdminUserNameRule) Check(runner tflint
 		err := runner.EvaluateExpr(attribute.Expr, &val)
 
 		return runner.EnsureNoError(err, func() error {
-			valid, err := isValidVMAdminUserNames(val)
+			valid, err := isValidVMAdminUserName(val)
 			if err != nil {
 				panic(err)
 			}

--- a/rules/azurerm_linux_virtual_machine_invalid_admin_username.go
+++ b/rules/azurerm_linux_virtual_machine_invalid_admin_username.go
@@ -1,0 +1,108 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-azurerm/project"
+)
+
+// AzurermLinuxVirtualMachineInvalidAdminUserNameRule ensures that invalid usernames are not set.
+type AzurermLinuxVirtualMachineInvalidAdminUserNameRule struct {
+	resourceType  string
+	attributeName string
+	enum          []string
+}
+
+// Please see: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-username-requirements-when-creating-a-vm
+// NewAzurermLinuxVirtualMachineInvalidSizeRule returns new rule with default attributes
+func NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule() *AzurermLinuxVirtualMachineInvalidAdminUserNameRule {
+	return &AzurermLinuxVirtualMachineInvalidAdminUserNameRule{
+		resourceType:  "azurerm_linux_virtual_machine",
+		attributeName: "admin_username",
+		enum: []string{
+			"azureuser",
+			"1",
+			"123",
+			"a",
+			"actuser",
+			"adm",
+			"admin",
+			"admin1",
+			"admin2",
+			"administrator",
+			"aspnet",
+			"backup",
+			"console",
+			"david",
+			"guest",
+			"john",
+			"owner",
+			"root",
+			"server",
+			"sql",
+			"support_388945a0",
+			"support",
+			"sys",
+			"test",
+			"test1",
+			"test2",
+			"test3",
+			"user",
+			"user1",
+			"user2",
+			"user3",
+			"user4",
+			"user5",
+			"video",
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AzurermLinuxVirtualMachineInvalidAdminUserNameRule) Name() string {
+	return "azurerm_linux_virtual_machine_invalid_admin_username"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AzurermLinuxVirtualMachineInvalidAdminUserNameRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AzurermLinuxVirtualMachineInvalidAdminUserNameRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AzurermLinuxVirtualMachineInvalidAdminUserNameRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks the pattern is valid
+func (r *AzurermLinuxVirtualMachineInvalidAdminUserNameRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var val string
+		err := runner.EvaluateExpr(attribute.Expr, &val)
+
+		return runner.EnsureNoError(err, func() error {
+			found := false
+			val = strings.ToLower(val)
+			for _, item := range r.enum {
+				if strings.ToLower(item) == val {
+					found = true
+				}
+			}
+			if found {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf(`"%s" is not a valid Linux VM Admin username`, val),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/azurerm_linux_virtual_machine_invalid_admin_username_test.go
+++ b/rules/azurerm_linux_virtual_machine_invalid_admin_username_test.go
@@ -88,7 +88,7 @@ var AzurermLinuxVirtualMachineInvalidAdminUserNameRuleTestCases = []struct {
 		expected: helper.Issues{
 			{
 				Rule:    NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule(),
-				Message: "\"azureuser\" is not a valid Linux VM Admin username",
+				Message: "\"AzureUser\" is not a valid Linux VM Admin username",
 				Range: hcl.Range{
 					Filename: "instances.tf",
 					Start:    hcl.Pos{Line: 3, Column: 22},

--- a/rules/azurerm_linux_virtual_machine_invalid_admin_username_test.go
+++ b/rules/azurerm_linux_virtual_machine_invalid_admin_username_test.go
@@ -1,0 +1,100 @@
+package rules
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AzurermLinuxVirtualMachineInvalidAdminUserNameRule(t *testing.T) {
+	for _, test := range AzurermLinuxVirtualMachineInvalidAdminUserNameRuleTestCases {
+		testDisplay := fmt.Sprintf("%d - %s", test.testID, test.testName)
+		t.Run(testDisplay, func(t *testing.T) {
+			//arrange
+			rule := *(NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule())
+			runner := helper.TestRunner(t, map[string]string{"instances.tf": test.hcl})
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			//act
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			//assert
+			helper.AssertIssues(t, test.expected, runner.Issues)
+
+		})
+	}
+}
+
+var AzurermLinuxVirtualMachineInvalidAdminUserNameRuleTestCases = []struct {
+	testID   int
+	testName string
+	hcl      string
+	expected helper.Issues
+}{
+	{
+		testID:   1,
+		testName: "123 is not allowed.",
+		hcl: `
+			resource "azurerm_linux_virtual_machine" "test" {
+				admin_username = "123"
+			}
+		`,
+		expected: helper.Issues{
+			{
+				Rule:    NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule(),
+				Message: "\"123\" is not a valid Linux VM Admin username",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 3, Column: 22},
+					End:      hcl.Pos{Line: 3, Column: 27},
+				},
+			},
+		},
+	},
+	{
+		testID:   2,
+		testName: "root is not allowed.",
+		hcl: `
+			resource "azurerm_linux_virtual_machine" "test" {
+				admin_username = "root"
+			}
+		`,
+		expected: helper.Issues{
+			{
+				Rule:    NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule(),
+				Message: "\"root\" is not a valid Linux VM Admin username",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 3, Column: 22},
+					End:      hcl.Pos{Line: 3, Column: 28},
+				},
+			},
+		},
+	},
+	{
+		testID:   3,
+		testName: "azureUser is not allowed.",
+		hcl: `
+			resource "azurerm_linux_virtual_machine" "test" {
+				admin_username = "AzureUser"
+			}
+		`,
+		expected: helper.Issues{
+			{
+				Rule:    NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule(),
+				Message: "\"azureuser\" is not a valid Linux VM Admin username",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 3, Column: 22},
+					End:      hcl.Pos{Line: 3, Column: 33},
+				},
+			},
+		},
+	},
+}

--- a/rules/azurerm_linux_virtual_machine_invalid_admin_username_test.go
+++ b/rules/azurerm_linux_virtual_machine_invalid_admin_username_test.go
@@ -97,4 +97,14 @@ var AzurermLinuxVirtualMachineInvalidAdminUserNameRuleTestCases = []struct {
 			},
 		},
 	},
+	{
+		testID:   4,
+		testName: "testUserFoo is allowed.",
+		hcl: `
+			resource "azurerm_linux_virtual_machine" "test" {
+				admin_username = "testUserFoo"
+			}
+		`,
+		expected: helper.Issues{},
+	},
 }

--- a/rules/azurerm_linux_virtual_machine_invalid_admin_username_test.go
+++ b/rules/azurerm_linux_virtual_machine_invalid_admin_username_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 )
@@ -16,8 +15,6 @@ func Test_AzurermLinuxVirtualMachineInvalidAdminUserNameRule(t *testing.T) {
 			//arrange
 			rule := *(NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule())
 			runner := helper.TestRunner(t, map[string]string{"instances.tf": test.hcl})
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			//act
 			if err := rule.Check(runner); err != nil {

--- a/rules/azurerm_virtual_machine_invalid_admin_username.go
+++ b/rules/azurerm_virtual_machine_invalid_admin_username.go
@@ -1,5 +1,7 @@
 package rules
 
+// Please see: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-username-requirements-when-creating-a-vm
+
 import (
 	"fmt"
 	"strings"
@@ -16,7 +18,6 @@ type AzurermVirtualMachineInvalidAdminUserNameRule struct {
 	enum          []string
 }
 
-// Please see: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-username-requirements-when-creating-a-vm
 // NewAzurermVirtualMachineInvalidAdminUserNameRule returns new rule with default attributes
 func NewAzurermVirtualMachineInvalidAdminUserNameRule() *AzurermVirtualMachineInvalidAdminUserNameRule {
 	return &AzurermVirtualMachineInvalidAdminUserNameRule{

--- a/rules/azurerm_virtual_machine_invalid_admin_username.go
+++ b/rules/azurerm_virtual_machine_invalid_admin_username.go
@@ -59,7 +59,7 @@ func (r *AzurermVirtualMachineInvalidAdminUserNameRule) Check(runner tflint.Runn
 		if attr, exists := content.Attributes["admin_username"]; exists {
 			var val string
 			err := runner.EvaluateExpr(attr.Expr, &val)
-			valid, err := isValidVMAdminUserNames(val)
+			valid, err := isValidVMAdminUserName(val)
 			if err != nil {
 				panic(err)
 			}

--- a/rules/azurerm_virtual_machine_invalid_admin_username.go
+++ b/rules/azurerm_virtual_machine_invalid_admin_username.go
@@ -47,10 +47,6 @@ func (r *AzurermVirtualMachineInvalidAdminUserNameRule) Link() string {
 // Check checks the pattern is valid
 func (r *AzurermVirtualMachineInvalidAdminUserNameRule) Check(runner tflint.Runner) error {
 	return runner.WalkResourceBlocks("azurerm_virtual_machine", "os_profile", func(block *hcl.Block) error {
-		if err := runner.EmitIssue(r, "`os_profile` block found", block.DefRange); err != nil {
-			return err
-		}
-
 		content, _, diags := block.Body.PartialContent(&hcl.BodySchema{
 			Attributes: []hcl.AttributeSchema{
 				{Name: "admin_username"},
@@ -61,13 +57,9 @@ func (r *AzurermVirtualMachineInvalidAdminUserNameRule) Check(runner tflint.Runn
 		}
 
 		if attr, exists := content.Attributes["admin_username"]; exists {
-			if err := runner.EmitIssueOnExpr(r, "`admin_username` attribute found", attr.Expr); err != nil {
-				return err
-			}
-
 			var val string
 			err := runner.EvaluateExpr(attr.Expr, &val)
-			valid, err := isVlidVMAdminUserNames(val)
+			valid, err := isValidVMAdminUserNames(val)
 			if err != nil {
 				panic(err)
 			}

--- a/rules/azurerm_virtual_machine_invalid_admin_username.go
+++ b/rules/azurerm_virtual_machine_invalid_admin_username.go
@@ -4,7 +4,6 @@ package rules
 
 import (
 	"fmt"
-	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
@@ -15,7 +14,6 @@ import (
 type AzurermVirtualMachineInvalidAdminUserNameRule struct {
 	resourceType  string
 	attributeName string
-	enum          []string
 }
 
 // NewAzurermVirtualMachineInvalidAdminUserNameRule returns new rule with default attributes
@@ -23,42 +21,6 @@ func NewAzurermVirtualMachineInvalidAdminUserNameRule() *AzurermVirtualMachineIn
 	return &AzurermVirtualMachineInvalidAdminUserNameRule{
 		resourceType:  "azurerm_virtual_machine",
 		attributeName: "admin_username",
-		enum: []string{
-			"azureuser",
-			"1",
-			"123",
-			"a",
-			"actuser",
-			"adm",
-			"admin",
-			"admin1",
-			"admin2",
-			"administrator",
-			"aspnet",
-			"backup",
-			"console",
-			"david",
-			"guest",
-			"john",
-			"owner",
-			"root",
-			"server",
-			"sql",
-			"support_388945a0",
-			"support",
-			"sys",
-			"test",
-			"test1",
-			"test2",
-			"test3",
-			"user",
-			"user1",
-			"user2",
-			"user3",
-			"user4",
-			"user5",
-			"video",
-		},
 	}
 }
 
@@ -89,21 +51,20 @@ func (r *AzurermVirtualMachineInvalidAdminUserNameRule) Check(runner tflint.Runn
 		err := runner.EvaluateExpr(attribute.Expr, &val)
 
 		return runner.EnsureNoError(err, func() error {
-			found := false
-			val = strings.ToLower(val)
-			for _, item := range r.enum {
-				if strings.ToLower(item) == val {
-					found = true
-				}
+			valid, err := isVlidVMAdminUserNames(val)
+			if err != nil {
+				panic(err)
 			}
-			if found {
-				runner.EmitIssueOnExpr(
-					r,
-					fmt.Sprintf(`"%s" is not a valid VM Admin username`, val),
-					attribute.Expr,
-				)
+
+			if valid {
+				return nil
 			}
-			return nil
+
+			return runner.EmitIssueOnExpr(
+				r,
+				fmt.Sprintf(`"%s" is not a valid VM Admin username`, val),
+				attribute.Expr,
+			)
 		})
 	})
 }

--- a/rules/azurerm_virtual_machine_invalid_admin_username.go
+++ b/rules/azurerm_virtual_machine_invalid_admin_username.go
@@ -1,0 +1,108 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-azurerm/project"
+)
+
+// AzurermVirtualMachineInvalidAdminUserNameRule ensures that invalid usernames are not set.
+type AzurermVirtualMachineInvalidAdminUserNameRule struct {
+	resourceType  string
+	attributeName string
+	enum          []string
+}
+
+// Please see: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-username-requirements-when-creating-a-vm
+// NewAzurermVirtualMachineInvalidAdminUserNameRule returns new rule with default attributes
+func NewAzurermVirtualMachineInvalidAdminUserNameRule() *AzurermVirtualMachineInvalidAdminUserNameRule {
+	return &AzurermVirtualMachineInvalidAdminUserNameRule{
+		resourceType:  "azurerm_virtual_machine",
+		attributeName: "admin_username",
+		enum: []string{
+			"azureuser",
+			"1",
+			"123",
+			"a",
+			"actuser",
+			"adm",
+			"admin",
+			"admin1",
+			"admin2",
+			"administrator",
+			"aspnet",
+			"backup",
+			"console",
+			"david",
+			"guest",
+			"john",
+			"owner",
+			"root",
+			"server",
+			"sql",
+			"support_388945a0",
+			"support",
+			"sys",
+			"test",
+			"test1",
+			"test2",
+			"test3",
+			"user",
+			"user1",
+			"user2",
+			"user3",
+			"user4",
+			"user5",
+			"video",
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AzurermVirtualMachineInvalidAdminUserNameRule) Name() string {
+	return "azurerm_linux_virtual_machine_invalid_admin_username"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AzurermVirtualMachineInvalidAdminUserNameRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AzurermVirtualMachineInvalidAdminUserNameRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AzurermVirtualMachineInvalidAdminUserNameRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks the pattern is valid
+func (r *AzurermVirtualMachineInvalidAdminUserNameRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var val string
+		err := runner.EvaluateExpr(attribute.Expr, &val)
+
+		return runner.EnsureNoError(err, func() error {
+			found := false
+			val = strings.ToLower(val)
+			for _, item := range r.enum {
+				if strings.ToLower(item) == val {
+					found = true
+				}
+			}
+			if found {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf(`"%s" is not a valid VM Admin username`, val),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/azurerm_virtual_machine_invalid_admin_username_test.go
+++ b/rules/azurerm_virtual_machine_invalid_admin_username_test.go
@@ -50,24 +50,6 @@ var AzurermVirtualMachineInvalidAdminUserNameRuleTestCases = []struct {
 		expected: helper.Issues{
 			{
 				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
-				Message: "`os_profile` block found",
-				Range: hcl.Range{
-					Filename: "instances.tf",
-					Start:    hcl.Pos{Line: 3, Column: 5},
-					End:      hcl.Pos{Line: 3, Column: 15},
-				},
-			},
-			{
-				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
-				Message: "`admin_username` attribute found",
-				Range: hcl.Range{
-					Filename: "instances.tf",
-					Start:    hcl.Pos{Line: 4, Column: 23},
-					End:      hcl.Pos{Line: 4, Column: 28},
-				},
-			},
-			{
-				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
 				Message: "\"123\" is not a valid VM Admin username",
 				Range: hcl.Range{
 					Filename: "instances.tf",
@@ -88,24 +70,6 @@ var AzurermVirtualMachineInvalidAdminUserNameRuleTestCases = []struct {
 			}
 		`,
 		expected: helper.Issues{
-			{
-				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
-				Message: "`os_profile` block found",
-				Range: hcl.Range{
-					Filename: "instances.tf",
-					Start:    hcl.Pos{Line: 3, Column: 5},
-					End:      hcl.Pos{Line: 3, Column: 15},
-				},
-			},
-			{
-				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
-				Message: "`admin_username` attribute found",
-				Range: hcl.Range{
-					Filename: "instances.tf",
-					Start:    hcl.Pos{Line: 4, Column: 23},
-					End:      hcl.Pos{Line: 4, Column: 29},
-				},
-			},
 			{
 				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
 				Message: "\"root\" is not a valid VM Admin username",

--- a/rules/azurerm_virtual_machine_invalid_admin_username_test.go
+++ b/rules/azurerm_virtual_machine_invalid_admin_username_test.go
@@ -42,17 +42,37 @@ var AzurermVirtualMachineInvalidAdminUserNameRuleTestCases = []struct {
 		testName: "123 is not allowed.",
 		hcl: `
 			resource "azurerm_virtual_machine" "test" {
-				admin_username = "123"
+				os_profile {
+					admin_username = "123"
+				}
 			}
 		`,
 		expected: helper.Issues{
 			{
 				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
+				Message: "`os_profile` block found",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 3, Column: 5},
+					End:      hcl.Pos{Line: 3, Column: 15},
+				},
+			},
+			{
+				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
+				Message: "`admin_username` attribute found",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 4, Column: 23},
+					End:      hcl.Pos{Line: 4, Column: 28},
+				},
+			},
+			{
+				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
 				Message: "\"123\" is not a valid VM Admin username",
 				Range: hcl.Range{
 					Filename: "instances.tf",
-					Start:    hcl.Pos{Line: 3, Column: 22},
-					End:      hcl.Pos{Line: 3, Column: 27},
+					Start:    hcl.Pos{Line: 4, Column: 23},
+					End:      hcl.Pos{Line: 4, Column: 28},
 				},
 			},
 		},
@@ -62,37 +82,37 @@ var AzurermVirtualMachineInvalidAdminUserNameRuleTestCases = []struct {
 		testName: "root is not allowed.",
 		hcl: `
 			resource "azurerm_virtual_machine" "test" {
-				admin_username = "root"
+				os_profile {
+					admin_username = "root"
+				}
 			}
 		`,
 		expected: helper.Issues{
+			{
+				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
+				Message: "`os_profile` block found",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 3, Column: 5},
+					End:      hcl.Pos{Line: 3, Column: 15},
+				},
+			},
+			{
+				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
+				Message: "`admin_username` attribute found",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 4, Column: 23},
+					End:      hcl.Pos{Line: 4, Column: 29},
+				},
+			},
 			{
 				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
 				Message: "\"root\" is not a valid VM Admin username",
 				Range: hcl.Range{
 					Filename: "instances.tf",
-					Start:    hcl.Pos{Line: 3, Column: 22},
-					End:      hcl.Pos{Line: 3, Column: 28},
-				},
-			},
-		},
-	},
-	{
-		testID:   3,
-		testName: "azureUser is not allowed.",
-		hcl: `
-			resource "azurerm_virtual_machine" "test" {
-				admin_username = "AzureUser"
-			}
-		`,
-		expected: helper.Issues{
-			{
-				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
-				Message: "\"AzureUser\" is not a valid VM Admin username",
-				Range: hcl.Range{
-					Filename: "instances.tf",
-					Start:    hcl.Pos{Line: 3, Column: 22},
-					End:      hcl.Pos{Line: 3, Column: 33},
+					Start:    hcl.Pos{Line: 4, Column: 23},
+					End:      hcl.Pos{Line: 4, Column: 29},
 				},
 			},
 		},

--- a/rules/azurerm_virtual_machine_invalid_admin_username_test.go
+++ b/rules/azurerm_virtual_machine_invalid_admin_username_test.go
@@ -88,7 +88,7 @@ var AzurermVirtualMachineInvalidAdminUserNameRuleTestCases = []struct {
 		expected: helper.Issues{
 			{
 				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
-				Message: "\"azureuser\" is not a valid VM Admin username",
+				Message: "\"AzureUser\" is not a valid VM Admin username",
 				Range: hcl.Range{
 					Filename: "instances.tf",
 					Start:    hcl.Pos{Line: 3, Column: 22},

--- a/rules/azurerm_virtual_machine_invalid_admin_username_test.go
+++ b/rules/azurerm_virtual_machine_invalid_admin_username_test.go
@@ -1,0 +1,100 @@
+package rules
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AzurermVirtualMachineInvalidAdminUserNameRule(t *testing.T) {
+	for _, test := range AzurermVirtualMachineInvalidAdminUserNameRuleTestCases {
+		testDisplay := fmt.Sprintf("%d - %s", test.testID, test.testName)
+		t.Run(testDisplay, func(t *testing.T) {
+			//arrange
+			rule := *(NewAzurermVirtualMachineInvalidAdminUserNameRule())
+			runner := helper.TestRunner(t, map[string]string{"instances.tf": test.hcl})
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			//act
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			//assert
+			helper.AssertIssues(t, test.expected, runner.Issues)
+
+		})
+	}
+}
+
+var AzurermVirtualMachineInvalidAdminUserNameRuleTestCases = []struct {
+	testID   int
+	testName string
+	hcl      string
+	expected helper.Issues
+}{
+	{
+		testID:   1,
+		testName: "123 is not allowed.",
+		hcl: `
+			resource "azurerm_virtual_machine" "test" {
+				admin_username = "123"
+			}
+		`,
+		expected: helper.Issues{
+			{
+				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
+				Message: "\"123\" is not a valid VM Admin username",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 3, Column: 22},
+					End:      hcl.Pos{Line: 3, Column: 27},
+				},
+			},
+		},
+	},
+	{
+		testID:   2,
+		testName: "root is not allowed.",
+		hcl: `
+			resource "azurerm_virtual_machine" "test" {
+				admin_username = "root"
+			}
+		`,
+		expected: helper.Issues{
+			{
+				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
+				Message: "\"root\" is not a valid VM Admin username",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 3, Column: 22},
+					End:      hcl.Pos{Line: 3, Column: 28},
+				},
+			},
+		},
+	},
+	{
+		testID:   3,
+		testName: "azureUser is not allowed.",
+		hcl: `
+			resource "azurerm_virtual_machine" "test" {
+				admin_username = "AzureUser"
+			}
+		`,
+		expected: helper.Issues{
+			{
+				Rule:    NewAzurermVirtualMachineInvalidAdminUserNameRule(),
+				Message: "\"azureuser\" is not a valid VM Admin username",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 3, Column: 22},
+					End:      hcl.Pos{Line: 3, Column: 33},
+				},
+			},
+		},
+	},
+}

--- a/rules/azurerm_virtual_machine_invalid_admin_username_test.go
+++ b/rules/azurerm_virtual_machine_invalid_admin_username_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 )
@@ -16,8 +15,6 @@ func Test_AzurermVirtualMachineInvalidAdminUserNameRule(t *testing.T) {
 			//arrange
 			rule := *(NewAzurermVirtualMachineInvalidAdminUserNameRule())
 			runner := helper.TestRunner(t, map[string]string{"instances.tf": test.hcl})
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			//act
 			if err := rule.Check(runner); err != nil {

--- a/rules/azurerm_windows_virtual_machine_invalid_admin_username.go
+++ b/rules/azurerm_windows_virtual_machine_invalid_admin_username.go
@@ -52,7 +52,7 @@ func (r *AzurermWindowsVirtualMachineInvalidAdminUserNameRule) Check(runner tfli
 		err := runner.EvaluateExpr(attribute.Expr, &val)
 
 		return runner.EnsureNoError(err, func() error {
-			valid, err := isValidVMAdminUserNames(val)
+			valid, err := isValidVMAdminUserName(val)
 			if err != nil {
 				panic(err)
 			}

--- a/rules/azurerm_windows_virtual_machine_invalid_admin_username.go
+++ b/rules/azurerm_windows_virtual_machine_invalid_admin_username.go
@@ -52,7 +52,7 @@ func (r *AzurermWindowsVirtualMachineInvalidAdminUserNameRule) Check(runner tfli
 		err := runner.EvaluateExpr(attribute.Expr, &val)
 
 		return runner.EnsureNoError(err, func() error {
-			valid, err := isVlidVMAdminUserNames(val)
+			valid, err := isValidVMAdminUserNames(val)
 			if err != nil {
 				panic(err)
 			}

--- a/rules/azurerm_windows_virtual_machine_invalid_admin_username.go
+++ b/rules/azurerm_windows_virtual_machine_invalid_admin_username.go
@@ -4,7 +4,6 @@ package rules
 
 import (
 	"fmt"
-	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
@@ -23,42 +22,6 @@ func NewAzurermWindowsVirtualMachineInvalidAdminUserNameRule() *AzurermWindowsVi
 	return &AzurermWindowsVirtualMachineInvalidAdminUserNameRule{
 		resourceType:  "azurerm_windows_virtual_machine",
 		attributeName: "admin_username",
-		enum: []string{
-			"azureuser",
-			"1",
-			"123",
-			"a",
-			"actuser",
-			"adm",
-			"admin",
-			"admin1",
-			"admin2",
-			"administrator",
-			"aspnet",
-			"backup",
-			"console",
-			"david",
-			"guest",
-			"john",
-			"owner",
-			"root",
-			"server",
-			"sql",
-			"support_388945a0",
-			"support",
-			"sys",
-			"test",
-			"test1",
-			"test2",
-			"test3",
-			"user",
-			"user1",
-			"user2",
-			"user3",
-			"user4",
-			"user5",
-			"video",
-		},
 	}
 }
 
@@ -89,21 +52,20 @@ func (r *AzurermWindowsVirtualMachineInvalidAdminUserNameRule) Check(runner tfli
 		err := runner.EvaluateExpr(attribute.Expr, &val)
 
 		return runner.EnsureNoError(err, func() error {
-			found := false
-			val = strings.ToLower(val)
-			for _, item := range r.enum {
-				if strings.ToLower(item) == val {
-					found = true
-				}
+			valid, err := isVlidVMAdminUserNames(val)
+			if err != nil {
+				panic(err)
 			}
-			if found {
-				runner.EmitIssueOnExpr(
-					r,
-					fmt.Sprintf(`"%s" is not a valid Windows VM Admin username`, val),
-					attribute.Expr,
-				)
+
+			if valid {
+				return nil
 			}
-			return nil
+
+			return runner.EmitIssueOnExpr(
+				r,
+				fmt.Sprintf(`"%s" is not a valid Windows VM Admin username`, val),
+				attribute.Expr,
+			)
 		})
 	})
 }

--- a/rules/azurerm_windows_virtual_machine_invalid_admin_username.go
+++ b/rules/azurerm_windows_virtual_machine_invalid_admin_username.go
@@ -1,5 +1,7 @@
 package rules
 
+// Please see: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/faq
+
 import (
 	"fmt"
 	"strings"
@@ -16,8 +18,7 @@ type AzurermWindowsVirtualMachineInvalidAdminUserNameRule struct {
 	enum          []string
 }
 
-// Please see: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/faq
-// NewAzurermWindowsVirtualMachineInvalidSizeRule returns new rule with default attributes
+// NewAzurermWindowsVirtualMachineInvalidAdminUserNameRule returns new rule with default attributes
 func NewAzurermWindowsVirtualMachineInvalidAdminUserNameRule() *AzurermWindowsVirtualMachineInvalidAdminUserNameRule {
 	return &AzurermWindowsVirtualMachineInvalidAdminUserNameRule{
 		resourceType:  "azurerm_windows_virtual_machine",

--- a/rules/azurerm_windows_virtual_machine_invalid_admin_username.go
+++ b/rules/azurerm_windows_virtual_machine_invalid_admin_username.go
@@ -9,18 +9,18 @@ import (
 	"github.com/terraform-linters/tflint-ruleset-azurerm/project"
 )
 
-// AzurermVirtualMachineInvalidAdminUserNameRule ensures that invalid usernames are not set.
-type AzurermVirtualMachineInvalidAdminUserNameRule struct {
+// AzurermWindowsVirtualMachineInvalidAdminUserNameRule ensures that invalid usernames are not set.
+type AzurermWindowsVirtualMachineInvalidAdminUserNameRule struct {
 	resourceType  string
 	attributeName string
 	enum          []string
 }
 
-// Please see: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-username-requirements-when-creating-a-vm
-// NewAzurermVirtualMachineInvalidAdminUserNameRule returns new rule with default attributes
-func NewAzurermVirtualMachineInvalidAdminUserNameRule() *AzurermVirtualMachineInvalidAdminUserNameRule {
-	return &AzurermVirtualMachineInvalidAdminUserNameRule{
-		resourceType:  "azurerm_virtual_machine",
+// Please see: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/faq
+// NewAzurermWindowsVirtualMachineInvalidSizeRule returns new rule with default attributes
+func NewAzurermWindowsVirtualMachineInvalidAdminUserNameRule() *AzurermWindowsVirtualMachineInvalidAdminUserNameRule {
+	return &AzurermWindowsVirtualMachineInvalidAdminUserNameRule{
+		resourceType:  "azurerm_windows_virtual_machine",
 		attributeName: "admin_username",
 		enum: []string{
 			"azureuser",
@@ -62,27 +62,27 @@ func NewAzurermVirtualMachineInvalidAdminUserNameRule() *AzurermVirtualMachineIn
 }
 
 // Name returns the rule name
-func (r *AzurermVirtualMachineInvalidAdminUserNameRule) Name() string {
-	return "azurerm_virtual_machine_invalid_admin_username"
+func (r *AzurermWindowsVirtualMachineInvalidAdminUserNameRule) Name() string {
+	return "azurerm_windows_virtual_machine_invalid_admin_username"
 }
 
 // Enabled returns whether the rule is enabled by default
-func (r *AzurermVirtualMachineInvalidAdminUserNameRule) Enabled() bool {
+func (r *AzurermWindowsVirtualMachineInvalidAdminUserNameRule) Enabled() bool {
 	return true
 }
 
 // Severity returns the rule severity
-func (r *AzurermVirtualMachineInvalidAdminUserNameRule) Severity() string {
+func (r *AzurermWindowsVirtualMachineInvalidAdminUserNameRule) Severity() string {
 	return tflint.ERROR
 }
 
 // Link returns the rule reference link
-func (r *AzurermVirtualMachineInvalidAdminUserNameRule) Link() string {
+func (r *AzurermWindowsVirtualMachineInvalidAdminUserNameRule) Link() string {
 	return project.ReferenceLink(r.Name())
 }
 
 // Check checks the pattern is valid
-func (r *AzurermVirtualMachineInvalidAdminUserNameRule) Check(runner tflint.Runner) error {
+func (r *AzurermWindowsVirtualMachineInvalidAdminUserNameRule) Check(runner tflint.Runner) error {
 	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
 		var val string
 		err := runner.EvaluateExpr(attribute.Expr, &val)
@@ -98,7 +98,7 @@ func (r *AzurermVirtualMachineInvalidAdminUserNameRule) Check(runner tflint.Runn
 			if found {
 				runner.EmitIssueOnExpr(
 					r,
-					fmt.Sprintf(`"%s" is not a valid VM Admin username`, val),
+					fmt.Sprintf(`"%s" is not a valid Windows VM Admin username`, val),
 					attribute.Expr,
 				)
 			}

--- a/rules/azurerm_windows_virtual_machine_invalid_admin_username_test.go
+++ b/rules/azurerm_windows_virtual_machine_invalid_admin_username_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 )
@@ -16,8 +15,6 @@ func Test_AzurermWindowsVirtualMachineInvalidAdminUserNameRule(t *testing.T) {
 			//arrange
 			rule := *(NewAzurermWindowsVirtualMachineInvalidAdminUserNameRule())
 			runner := helper.TestRunner(t, map[string]string{"instances.tf": test.hcl})
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			//act
 			if err := rule.Check(runner); err != nil {

--- a/rules/azurerm_windows_virtual_machine_invalid_admin_username_test.go
+++ b/rules/azurerm_windows_virtual_machine_invalid_admin_username_test.go
@@ -1,0 +1,100 @@
+package rules
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AzurermWindowsVirtualMachineInvalidAdminUserNameRule(t *testing.T) {
+	for _, test := range AzurermWindowsVirtualMachineInvalidAdminUserNameRuleTestCases {
+		testDisplay := fmt.Sprintf("%d - %s", test.testID, test.testName)
+		t.Run(testDisplay, func(t *testing.T) {
+			//arrange
+			rule := *(NewAzurermWindowsVirtualMachineInvalidAdminUserNameRule())
+			runner := helper.TestRunner(t, map[string]string{"instances.tf": test.hcl})
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			//act
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			//assert
+			helper.AssertIssues(t, test.expected, runner.Issues)
+
+		})
+	}
+}
+
+var AzurermWindowsVirtualMachineInvalidAdminUserNameRuleTestCases = []struct {
+	testID   int
+	testName string
+	hcl      string
+	expected helper.Issues
+}{
+	{
+		testID:   1,
+		testName: "123 is not allowed.",
+		hcl: `
+			resource "azurerm_windows_virtual_machine" "test" {
+				admin_username = "123"
+			}
+		`,
+		expected: helper.Issues{
+			{
+				Rule:    NewAzurermWindowsVirtualMachineInvalidAdminUserNameRule(),
+				Message: "\"123\" is not a valid Windows VM Admin username",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 3, Column: 22},
+					End:      hcl.Pos{Line: 3, Column: 27},
+				},
+			},
+		},
+	},
+	{
+		testID:   2,
+		testName: "root is not allowed.",
+		hcl: `
+			resource "azurerm_windows_virtual_machine" "test" {
+				admin_username = "root"
+			}
+		`,
+		expected: helper.Issues{
+			{
+				Rule:    NewAzurermWindowsVirtualMachineInvalidAdminUserNameRule(),
+				Message: "\"root\" is not a valid Windows VM Admin username",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 3, Column: 22},
+					End:      hcl.Pos{Line: 3, Column: 28},
+				},
+			},
+		},
+	},
+	{
+		testID:   3,
+		testName: "azureUser is not allowed.",
+		hcl: `
+			resource "azurerm_windows_virtual_machine" "test" {
+				admin_username = "AzureUser"
+			}
+		`,
+		expected: helper.Issues{
+			{
+				Rule:    NewAzurermWindowsVirtualMachineInvalidAdminUserNameRule(),
+				Message: "\"azureuser\" is not a valid Windows VM Admin username",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 3, Column: 22},
+					End:      hcl.Pos{Line: 3, Column: 33},
+				},
+			},
+		},
+	},
+}

--- a/rules/azurerm_windows_virtual_machine_invalid_admin_username_test.go
+++ b/rules/azurerm_windows_virtual_machine_invalid_admin_username_test.go
@@ -88,7 +88,7 @@ var AzurermWindowsVirtualMachineInvalidAdminUserNameRuleTestCases = []struct {
 		expected: helper.Issues{
 			{
 				Rule:    NewAzurermWindowsVirtualMachineInvalidAdminUserNameRule(),
-				Message: "\"azureuser\" is not a valid Windows VM Admin username",
+				Message: "\"AzureUser\" is not a valid Windows VM Admin username",
 				Range: hcl.Range{
 					Filename: "instances.tf",
 					Start:    hcl.Pos{Line: 3, Column: 22},

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -12,7 +12,7 @@ var Rules = append([]tflint.Rule{
 	NewAzurermVirtualMachineInvalidVMSizeRule(),
 	NewAzurermWindowsVirtualMachineInvalidSizeRule(),
 	NewAzurermWindowsVirtualMachineScaleSetInvalidSkuRule(),
-	NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule(),
-	NewAzurermVirtualMachineInvalidAdminUserNameRule(),
-	NewAzurermWindowsVirtualMachineInvalidAdminUserNameRule(),
+	// NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule(),
+	// NewAzurermVirtualMachineInvalidAdminUserNameRule(),
+	// NewAzurermWindowsVirtualMachineInvalidAdminUserNameRule(),
 }, apispec.Rules...)

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -12,7 +12,7 @@ var Rules = append([]tflint.Rule{
 	NewAzurermVirtualMachineInvalidVMSizeRule(),
 	NewAzurermWindowsVirtualMachineInvalidSizeRule(),
 	NewAzurermWindowsVirtualMachineScaleSetInvalidSkuRule(),
-	// NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule(),
-	// NewAzurermVirtualMachineInvalidAdminUserNameRule(),
-	// NewAzurermWindowsVirtualMachineInvalidAdminUserNameRule(),
+	NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule(),
+	NewAzurermVirtualMachineInvalidAdminUserNameRule(),
+	NewAzurermWindowsVirtualMachineInvalidAdminUserNameRule(),
 }, apispec.Rules...)

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -12,4 +12,5 @@ var Rules = append([]tflint.Rule{
 	NewAzurermVirtualMachineInvalidVMSizeRule(),
 	NewAzurermWindowsVirtualMachineInvalidSizeRule(),
 	NewAzurermWindowsVirtualMachineScaleSetInvalidSkuRule(),
+	NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule(),
 }, apispec.Rules...)

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -13,4 +13,6 @@ var Rules = append([]tflint.Rule{
 	NewAzurermWindowsVirtualMachineInvalidSizeRule(),
 	NewAzurermWindowsVirtualMachineScaleSetInvalidSkuRule(),
 	NewAzurermLinuxVirtualMachineInvalidAdminUserNameRule(),
+	NewAzurermVirtualMachineInvalidAdminUserNameRule(),
+	NewAzurermWindowsVirtualMachineInvalidAdminUserNameRule(),
 }, apispec.Rules...)

--- a/rules/utils.go
+++ b/rules/utils.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"errors"
+	"strings"
+)
+
+var validVMAdminUserNames = map[string]bool{
+	"azureuser":        false,
+	"1":                false,
+	"123":              false,
+	"a":                false,
+	"actuser":          false,
+	"adm":              false,
+	"admin":            false,
+	"admin1":           false,
+	"admin2":           false,
+	"administrator":    false,
+	"aspnet":           false,
+	"backup":           false,
+	"console":          false,
+	"david":            false,
+	"guest":            false,
+	"john":             false,
+	"owner":            false,
+	"root":             false,
+	"server":           false,
+	"sql":              false,
+	"support_388945a0": false,
+	"support":          false,
+	"sys":              false,
+	"test":             false,
+	"test1":            false,
+	"test2":            false,
+	"test3":            false,
+	"user":             false,
+	"user1":            false,
+	"user2":            false,
+	"user3":            false,
+	"user4":            false,
+	"user5":            false,
+	"video":            false,
+}
+
+func isVlidVMAdminUserNames(userName string) (bool, error) {
+	if userName == "" {
+		return false, errors.New("userName is empty")
+	}
+	return validVMAdminUserNames[strings.ToLower(userName)], nil
+}

--- a/rules/utils.go
+++ b/rules/utils.go
@@ -42,7 +42,7 @@ var validVMAdminUserNames = map[string]bool{
 	"video":            false,
 }
 
-func isValidVMAdminUserNames(userName string) (bool, error) {
+func isValidVMAdminUserName(userName string) (bool, error) {
 	if userName == "" {
 		return false, errors.New("userName is empty")
 	}

--- a/rules/utils.go
+++ b/rules/utils.go
@@ -42,9 +42,13 @@ var validVMAdminUserNames = map[string]bool{
 	"video":            false,
 }
 
-func isVlidVMAdminUserNames(userName string) (bool, error) {
+func isValidVMAdminUserNames(userName string) (bool, error) {
 	if userName == "" {
 		return false, errors.New("userName is empty")
 	}
-	return validVMAdminUserNames[strings.ToLower(userName)], nil
+	userName = strings.ToLower(userName)
+	if val, ok := validVMAdminUserNames[userName]; ok {
+		return val, nil
+	}
+	return true, nil
 }

--- a/tools/README.md
+++ b/tools/README.md
@@ -8,6 +8,34 @@ This script generate rules from [azure-rest-api-specs](https://github.com/Azure/
 
 The correspondence between API definitions and Terraform attributes is defined in the [mapping files](apispec-rule-gen/mappings). It also includes Terraform's schema file to check for invalid mappings.
 
+### Debugging with VS Code
+
+* Open the root of this repo in [VS Code](https://code.visualstudio.com/).
+* Install the [Go Extension for VS Code](https://github.com/golang/vscode-go) via the Extensions icon on the left hand menu.
+* Press F5 to start the debugger or click on 'Run' -> 'Start Debugging'
+
+The launch.json file provides default values for the tool base path, rule generation target path and doc generation target path. You can override these if needed.
+
+```json
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/tools/apispec-rule-gen/",
+      "env": {},
+      "args": [
+        "-base-path=.",
+        "-rules-path=../../rules",
+        "-docs-path=../../docs"
+      ]
+    }
+  ]
+}
+```
+
 ### Update azure-rest-api-specs
 
 ```console

--- a/tools/apispec-rule-gen/doc_README.md.tmpl
+++ b/tools/apispec-rule-gen/doc_README.md.tmpl
@@ -6,9 +6,12 @@ This documentation describes a list of rules available by enabling this ruleset.
 
 |Rule|Enabled by default|
 | --- | --- |
+|[azurerm_linux_virtual_machine_admin_username](rules/azurerm_linux_virtual_machine_admin_username.md)|✔|
 |[azurerm_linux_virtual_machine_invalid_size](rules/azurerm_linux_virtual_machine_invalid_size.md)|✔|
 |[azurerm_linux_virtual_machine_scale_set_invalid_sku](rules/azurerm_linux_virtual_machine_scale_set_invalid_sku.md)|✔|
+|[azurerm_virtual_machine_admin_username](rules/azurerm_linux_virtual_machine_admin_username.md)|✔|
 |[azurerm_virtual_machine_invalid_vm_size](rules/azurerm_virtual_machine_invalid_vm_size.md)|✔|
+|[azurerm_windows_virtual_machine_admin_username](rules/azurerm_windows_virtual_machine_admin_username.md)|✔|
 |[azurerm_windows_virtual_machine_invalid_size](rules/azurerm_windows_virtual_machine_invalid_size.md)|✔|
 |[azurerm_windows_virtual_machine_scale_set_invalid_sku](rules/azurerm_windows_virtual_machine_scale_set_invalid_sku.md)|✔|
 

--- a/tools/apispec-rule-gen/schema.go
+++ b/tools/apispec-rule-gen/schema.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 )
 
@@ -32,7 +33,10 @@ type attribute struct {
 }
 
 func loadProviderSchema() provider {
-	src, err := ioutil.ReadFile("apispec-rule-gen/schema/schema.json")
+	schemaPath := getFullPath("schema/schema.json")
+	fmt.Println(schemaPath)
+	src, err := ioutil.ReadFile(schemaPath)
+
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
There are restrictions on admin usernames for Azure VMs (Linux VMs, Windows VM and legacy tf provider virtual machine resource.)
Please see: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/faq#what-are-the-username-requirements-when-creating-a-vm

The names specified here are referenced in the openapi spec for the Azure Api but are not part of the swagger doc regex. As such I added a custom rule to support linting of admin usernames on the types.