### PR TITLE
Adding Azure Store Account Name Rule

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/tools/apispec-rule-gen/",
+      "env": {},
+      "args": [
+        "-base-path=.",
+        "-rules-path=../../rules",
+        "-docs-path=../../docs"
+      ]
+    }
+  ]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This documentation describes a list of rules available by enabling this ruleset.
 
 |Rule|Enabled by default|
 | --- | --- |
+|[azurerm_storage_account_invalid_name](rules/azurerm_storage_account_invalid_name.md)|✔|
 |[azurerm_linux_virtual_machine_invalid_size](rules/azurerm_linux_virtual_machine_invalid_size.md)|✔|
 |[azurerm_linux_virtual_machine_scale_set_invalid_sku](rules/azurerm_linux_virtual_machine_scale_set_invalid_sku.md)|✔|
 |[azurerm_virtual_machine_invalid_vm_size](rules/azurerm_virtual_machine_invalid_vm_size.md)|✔|

--- a/docs/rules/azurerm_storage_account_invalid_name.md
+++ b/docs/rules/azurerm_storage_account_invalid_name.md
@@ -1,0 +1,45 @@
+
+# azurerm_storage_account_invalid_name
+
+Warns about invalid storage account names.
+
+Allowed values are:
+- Mininum length 3.
+- Maximum length 24.	
+- Lowercase letters and numbers.
+
+Note: Storage account names are globally unique, this rule only validates the name format, but not it's uniqueness. 
+## Example
+
+```hcl
+
+resource "azurerm_storage_account" "example" {
+  name  = "AA123"
+}
+
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Error: "AA123" does not match valid pattern ^[a-z0-9]{3,24}$ (azurerm_storage_account_invalid_name)
+
+  on main.tf line 82:
+  82:   name                     = "AA123"
+
+Reference: https://github.com/terraform-linters/tflint-ruleset-azurerm/blob/v0.5.1/docs/rules/azurerm_storage_account_invalid_name.md
+
+```
+
+## Why
+
+Requests containing invalid values will return an error when calling the API by `terraform apply`.
+
+## How to Fix
+
+Replace the warned value with a valid value.
+
+## Source
+
+https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/terraform-linters/tflint-ruleset-azurerm
 go 1.15
 
 require (
+	github.com/golang/mock v1.1.1
 	github.com/google/go-cmp v0.5.2
 	github.com/hashicorp/hcl/v2 v2.6.0
 	github.com/terraform-linters/tflint-plugin-sdk v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,7 @@ github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=

--- a/rules/azurerm_storage_account_invalid_name.go
+++ b/rules/azurerm_storage_account_invalid_name.go
@@ -1,5 +1,7 @@
 package rules
 
+// Please see https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage
+
 import (
 	"fmt"
 	"regexp"

--- a/rules/azurerm_storage_account_invalid_name.go
+++ b/rules/azurerm_storage_account_invalid_name.go
@@ -55,7 +55,7 @@ func (r *AzurermStorageAccountInvalidNameRule) Check(runner tflint.Runner) error
 			if !r.pattern.MatchString(val) {
 				runner.EmitIssueOnExpr(
 					r,
-					fmt.Sprintf(`"%s" does not match valid pattern %s`, truncateLongMessage(val), `^[a-z0-9]{3,24}$`),
+					fmt.Sprintf(`"%s" does not match valid pattern %s`, val, `^[a-z0-9]{3,24}$`),
 					attribute.Expr,
 				)
 			}

--- a/rules/azurerm_storage_account_invalid_name.go
+++ b/rules/azurerm_storage_account_invalid_name.go
@@ -1,0 +1,65 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-azurerm/project"
+)
+
+// AzurermStorageAccountInvalidNameRule checks the pattern is valid
+type AzurermStorageAccountInvalidNameRule struct {
+	resourceType  string
+	attributeName string
+	pattern       *regexp.Regexp
+}
+
+// NewAzurermStorageAccountInvalidNameRule returns new rule with default attributes
+func NewAzurermStorageAccountInvalidNameRule() *AzurermStorageAccountInvalidNameRule {
+	return &AzurermStorageAccountInvalidNameRule{
+		resourceType:  "azurerm_storage_account",
+		attributeName: "name",
+		pattern:       regexp.MustCompile(`^[a-z]{3, 24}$`),
+	}
+}
+
+// Name returns the rule name
+func (r *AzurermStorageAccountInvalidNameRule) Name() string {
+	return "azurerm_storage_account_invalid_name"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AzurermStorageAccountInvalidNameRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AzurermStorageAccountInvalidNameRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AzurermStorageAccountInvalidNameRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks the pattern is valid
+func (r *AzurermStorageAccountInvalidNameRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var val string
+		err := runner.EvaluateExpr(attribute.Expr, &val)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.pattern.MatchString(val) {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf(`"%s" does not match valid pattern %s`, truncateLongMessage(val), `^[a-z]{3, 24}$`),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/azurerm_storage_account_invalid_name.go
+++ b/rules/azurerm_storage_account_invalid_name.go
@@ -21,7 +21,7 @@ func NewAzurermStorageAccountInvalidNameRule() *AzurermStorageAccountInvalidName
 	return &AzurermStorageAccountInvalidNameRule{
 		resourceType:  "azurerm_storage_account",
 		attributeName: "name",
-		pattern:       regexp.MustCompile(`^[a-z]{3, 24}$`),
+		pattern:       regexp.MustCompile(`^[a-z0-9]{3,24}$`),
 	}
 }
 
@@ -55,7 +55,7 @@ func (r *AzurermStorageAccountInvalidNameRule) Check(runner tflint.Runner) error
 			if !r.pattern.MatchString(val) {
 				runner.EmitIssueOnExpr(
 					r,
-					fmt.Sprintf(`"%s" does not match valid pattern %s`, truncateLongMessage(val), `^[a-z]{3, 24}$`),
+					fmt.Sprintf(`"%s" does not match valid pattern %s`, truncateLongMessage(val), `^[a-z0-9]{3,24}$`),
 					attribute.Expr,
 				)
 			}

--- a/rules/azurerm_storage_account_invalid_name_test.go
+++ b/rules/azurerm_storage_account_invalid_name_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 )
@@ -22,8 +21,6 @@ func Test_AzurermStorageAccountNameRule(t *testing.T) {
 		t.Run(testDisplay, func(t *testing.T) {
 			//arrange
 			runner := helper.TestRunner(t, map[string]string{"instances.tf": test.hcl})
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			//act
 			if err := rule.Check(runner); err != nil {

--- a/rules/azurerm_storage_account_invalid_name_test.go
+++ b/rules/azurerm_storage_account_invalid_name_test.go
@@ -1,0 +1,184 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+var rule = AzurermStorageAccountInvalidNameRule(AzurermStorageAccountInvalidNameRule{
+	resourceType:  "azurerm_storage_account",
+	attributeName: "name",
+	pattern:       regexp.MustCompile(`^[a-z0-9]{3,24}$`),
+})
+
+func Test_AzurermStorageAccountNameRule(t *testing.T) {
+	for _, test := range testCases {
+		testDisplay := fmt.Sprintf("%d - %s", test.testID, test.testName)
+		t.Run(testDisplay, func(t *testing.T) {
+			//arrange
+			runner := helper.TestRunner(t, map[string]string{"instances.tf": test.hcl})
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			//act
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			//assert
+			helper.AssertIssues(t, test.expected, runner.Issues)
+
+		})
+	}
+}
+
+var testCases = []struct {
+	testID   int
+	testName string
+	hcl      string
+	expected helper.Issues
+}{
+
+	{
+		testID:   1,
+		testName: "Upper Case Characters not allowed",
+		hcl: `
+			resource "azurerm_storage_account" "test" {
+				name = "Notavalidname"
+			}
+		`,
+		expected: helper.Issues{
+			{
+				Rule:    &rule,
+				Message: "\"Notavalidname\" does not match valid pattern ^[a-z0-9]{3,24}$",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 3, Column: 12},
+					End:      hcl.Pos{Line: 3, Column: 27},
+				},
+			},
+		},
+	},
+
+	{
+		testID:   2,
+		testName: "Non Alpha Numeric Characters not allowed",
+		hcl: `
+			resource "azurerm_storage_account" "test" {
+				name = "notavalid_name!"
+			}
+		`,
+		expected: helper.Issues{
+			{
+				Rule:    &rule,
+				Message: "\"notavalid_name!\" does not match valid pattern ^[a-z0-9]{3,24}$",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 3, Column: 12},
+					End:      hcl.Pos{Line: 3, Column: 29},
+				},
+			},
+		},
+	},
+
+	{
+		testID:   3,
+		testName: "Non Alpha Numeric Characters with numbers not allowed",
+		hcl: `
+			resource "azurerm_storage_account" "test" {
+				name = "Notavalid_name!3"
+			}
+		`,
+		expected: helper.Issues{
+			{
+				Rule:    &rule,
+				Message: "\"Notavalid_name!3\" does not match valid pattern ^[a-z0-9]{3,24}$",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 3, Column: 12},
+					End:      hcl.Pos{Line: 3, Column: 30},
+				},
+			},
+		},
+	},
+
+	{
+		testID:   4,
+		testName: "Less than 3 characters is Invalid",
+		hcl: `
+			resource "azurerm_storage_account" "test" {
+				name = "ab"
+			}
+		`,
+		expected: helper.Issues{
+			{
+				Rule:    &rule,
+				Message: "\"ab\" does not match valid pattern ^[a-z0-9]{3,24}$",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 3, Column: 12},
+					End:      hcl.Pos{Line: 3, Column: 16},
+				},
+			},
+		},
+	},
+
+	{
+		testID:   5,
+		testName: "Greater than 24 characters is invalid",
+		hcl: `
+			resource "azurerm_storage_account" "test" {
+				name = "abcdefghijklmnopqrstuvwxyz"
+			}
+		`,
+		expected: helper.Issues{
+			{
+				Rule:    &rule,
+				Message: "\"abcdefghijklmnopqrstuvwxyz\" does not match valid pattern ^[a-z0-9]{3,24}$",
+				Range: hcl.Range{
+					Filename: "instances.tf",
+					Start:    hcl.Pos{Line: 3, Column: 12},
+					End:      hcl.Pos{Line: 3, Column: 40},
+				},
+			},
+		},
+	},
+
+	{
+		testID:   6,
+		testName: "Between 3 and 24 characters is valid",
+		hcl: `
+			resource "azurerm_storage_account" "test" {
+				name = "abc1235"
+			}
+		`,
+		expected: helper.Issues{},
+	},
+
+	{
+		testID:   7,
+		testName: "Only letters is a valid",
+		hcl: `
+			resource "azurerm_storage_account" "test" {
+				name = "abcdef"
+			}
+		`,
+		expected: helper.Issues{},
+	},
+
+	{
+		testID:   8,
+		testName: "Only numbers is a valid",
+		hcl: `
+			resource "azurerm_storage_account" "test" {
+				name = "123456"
+			}
+		`,
+		expected: helper.Issues{},
+	},
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"strings"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/terraform-linters/tflint-ruleset-azurerm/rules/apispec"
 )
@@ -13,3 +15,17 @@ var Rules = append([]tflint.Rule{
 	NewAzurermWindowsVirtualMachineInvalidSizeRule(),
 	NewAzurermWindowsVirtualMachineScaleSetInvalidSkuRule(),
 }, apispec.Rules...)
+
+func truncateLongMessage(str string) string {
+	limit := 80
+
+	str = strings.Replace(str, "\r\n", "\n", -1)
+	str = strings.Replace(str, "\n", "\\n", -1)
+
+	r := []rune(str)
+	if len(r) > limit {
+		return string(r[0:limit]) + "..."
+	}
+
+	return str
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -1,8 +1,6 @@
 package rules
 
 import (
-	"strings"
-
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/terraform-linters/tflint-ruleset-azurerm/rules/apispec"
 )
@@ -15,17 +13,3 @@ var Rules = append([]tflint.Rule{
 	NewAzurermWindowsVirtualMachineInvalidSizeRule(),
 	NewAzurermWindowsVirtualMachineScaleSetInvalidSkuRule(),
 }, apispec.Rules...)
-
-func truncateLongMessage(str string) string {
-	limit := 80
-
-	str = strings.Replace(str, "\r\n", "\n", -1)
-	str = strings.Replace(str, "\n", "\\n", -1)
-
-	r := []rune(str)
-	if len(r) > limit {
-		return string(r[0:limit]) + "..."
-	}
-
-	return str
-}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -12,4 +12,5 @@ var Rules = append([]tflint.Rule{
 	NewAzurermVirtualMachineInvalidVMSizeRule(),
 	NewAzurermWindowsVirtualMachineInvalidSizeRule(),
 	NewAzurermWindowsVirtualMachineScaleSetInvalidSkuRule(),
+	NewAzurermStorageAccountInvalidNameRule(),
 }, apispec.Rules...)

--- a/tools/README.md
+++ b/tools/README.md
@@ -8,6 +8,34 @@ This script generate rules from [azure-rest-api-specs](https://github.com/Azure/
 
 The correspondence between API definitions and Terraform attributes is defined in the [mapping files](apispec-rule-gen/mappings). It also includes Terraform's schema file to check for invalid mappings.
 
+### Debugging with VS Code
+
+* Open the root of this repo in [VS Code](https://code.visualstudio.com/).
+* Install the [Go Extension for VS Code](https://github.com/golang/vscode-go) via the Extensions icon on the left hand menu.
+* Press F5 to start the debugger or click on 'Run' -> 'Start Debugging'
+
+The launch.json file provides default values for the tool base path, rule generation target path and doc generation target path. You can override these if needed.
+
+```json
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/tools/apispec-rule-gen/",
+      "env": {},
+      "args": [
+        "-base-path=.",
+        "-rules-path=../../rules",
+        "-docs-path=../../docs"
+      ]
+    }
+  ]
+}
+```
+
 ### Update azure-rest-api-specs
 
 ```console

--- a/tools/apispec-rule-gen/schema.go
+++ b/tools/apispec-rule-gen/schema.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 )
 
@@ -32,7 +33,10 @@ type attribute struct {
 }
 
 func loadProviderSchema() provider {
-	src, err := ioutil.ReadFile("apispec-rule-gen/schema/schema.json")
+	schemaPath := getFullPath("schema/schema.json")
+	fmt.Println(schemaPath)
+	src, err := ioutil.ReadFile(schemaPath)
+
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
There are naming rules for storage account (must be lower case only and alpha numeric, no special characters.) https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage 

Because the OpenApi spec for the Azure API does not contain a regex pattern this rule is not autogenerated. As such this PR adds a custom rule to allow checking for storage account names.