### PR TITLE
Add a make command to update the api spec submodule.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,11 @@ lint:
 tools:
 	go install golang.org/x/lint/golint
 
-.PHONY: test e2e build install lint tools
+updateSubmodule:
+	cd ./tools/apispec-rule-gen/azure-rest-api-specs/
+	git submodule update --init --recursive
+	cd ../../..
+
+
+
+.PHONY: test e2e build install lint tools updateSubmodule


### PR DESCRIPTION
This addition makes it easy to keep the azure rest api specs up to date using Make updateSubmodule command.