### PR TITLE
build: Update GoReleaser version

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,14 +1,15 @@
-name: release
+name: goreleaser
 
 on:
   push:
     branches:
-    - '!*'
-    tags:
-    - v*.*.*
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
-  goreleaser:
+  check:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -23,6 +24,4 @@ jobs:
       uses: goreleaser/goreleaser-action@v2
       with:
         version: v0.178.0
-        args: release --rm-dist
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        args: check


### PR DESCRIPTION
GoReleaser v0.169.0 doesn't support darwin/arm64 build with Go 1.17.
https://github.com/goreleaser/goreleaser/issues/2412

As a result, v0.13.0 release doesn't include darwin/arm64 build. This PR updates the GoReleaser version to fix the issue.