### PR TITLE
Fix github-script to v5

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          const issues = await github.issues.listForRepo({
+          const issues = await github.rest.issues.listForRepo({
             owner: 'terraform-linters',
             repo: 'tflint-ruleset-azurerm',
             state: 'open',
@@ -38,7 +38,7 @@ jobs:
             return
           }
 
-          github.issues.create({
+          github.rest.issues.create({
             owner: 'terraform-linters',
             repo: 'tflint-ruleset-azurerm',
             title: '🤖 MicrosoftDocs/azure-docs Changes Report',


### PR DESCRIPTION
The watch action is failed because actions/github-script upgrades to v5.
https://github.com/terraform-linters/tflint-ruleset-azurerm/actions/runs/1339792554

This change includes a breaking change. This PR fixes API calls by following https://github.com/actions/github-script/pull/193.