### PR TITLE
Bump terraform-provider-azurerm to v3.48.0 from v3.43.0

### DIFF
--- a/docs/rules/azurerm_kubernetes_cluster_invalid_name.md
+++ b/docs/rules/azurerm_kubernetes_cluster_invalid_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2022-03-02-preview/managedClusters.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-01-02-preview/managedClusters.json

--- a/docs/rules/azurerm_kubernetes_cluster_node_pool_invalid_os_disk_size_gb.md
+++ b/docs/rules/azurerm_kubernetes_cluster_node_pool_invalid_os_disk_size_gb.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2022-03-02-preview/managedClusters.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-01-02-preview/managedClusters.json

--- a/docs/rules/azurerm_kubernetes_cluster_node_pool_invalid_os_type.md
+++ b/docs/rules/azurerm_kubernetes_cluster_node_pool_invalid_os_type.md
@@ -41,4 +41,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2022-03-02-preview/managedClusters.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-01-02-preview/managedClusters.json

--- a/docs/rules/azurerm_redis_cache_invalid_family.md
+++ b/docs/rules/azurerm_redis_cache_invalid_family.md
@@ -41,4 +41,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/redis/resource-manager/Microsoft.Cache/stable/2022-06-01/redis.json

--- a/docs/rules/azurerm_redis_cache_invalid_minimum_tls_version.md
+++ b/docs/rules/azurerm_redis_cache_invalid_minimum_tls_version.md
@@ -42,4 +42,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/redis/resource-manager/Microsoft.Cache/stable/2022-06-01/redis.json

--- a/docs/rules/azurerm_redis_cache_invalid_private_static_ip_address.md
+++ b/docs/rules/azurerm_redis_cache_invalid_private_static_ip_address.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/redis/resource-manager/Microsoft.Cache/stable/2022-06-01/redis.json

--- a/docs/rules/azurerm_redis_cache_invalid_sku_name.md
+++ b/docs/rules/azurerm_redis_cache_invalid_sku_name.md
@@ -42,4 +42,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/redis/resource-manager/Microsoft.Cache/stable/2022-06-01/redis.json

--- a/docs/rules/azurerm_redis_cache_invalid_subnet_id.md
+++ b/docs/rules/azurerm_redis_cache_invalid_subnet_id.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/redis/resource-manager/Microsoft.Cache/stable/2022-06-01/redis.json

--- a/tools/apispec-rule-gen/mappings/azurerm_kubernetes_cluster.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_kubernetes_cluster.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_kubernetes_cluster" {
-  import_path = "azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2022-03-02-preview/managedClusters.json"
+  import_path = "azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-01-02-preview/managedClusters.json"
 
   name                       = ResourceNameParameter
   resource_group_name        = any //ResourceGroupNameParameter

--- a/tools/apispec-rule-gen/mappings/azurerm_kubernetes_cluster_node_pool.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_kubernetes_cluster_node_pool.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_kubernetes_cluster_node_pool" {
-  import_path = "azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2022-03-02-preview/managedClusters.json"
+  import_path = "azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-01-02-preview/managedClusters.json"
 
   vm_size               = any //ContainerServiceVMSize
   availability_zones    = ManagedClusterAgentPoolProfileProperties.availabilityZones

--- a/tools/apispec-rule-gen/mappings/azurerm_redis_cache.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_redis_cache.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_redis_cache" {
-  import_path = "azure-rest-api-specs/specification/redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json"
+  import_path = "azure-rest-api-specs/specification/redis/resource-manager/Microsoft.Cache/stable/2022-06-01/redis.json"
 
   location                  = RedisCreateParameters.location
   capacity                  = Sku.capacity

--- a/tools/apispec-rule-gen/mappings/azurerm_redis_firewall_rule.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_redis_firewall_rule.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_redis_firewall_rule" {
-  import_path = "azure-rest-api-specs/specification/redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json"
+  import_path = "azure-rest-api-specs/specification/redis/resource-manager/Microsoft.Cache/stable/2022-06-01/redis.json"
 
   start_ip = RedisFirewallRuleProperties.startIP
   end_ip   = RedisFirewallRuleProperties.endIP

--- a/tools/apispec-rule-gen/mappings/azurerm_signalr_service.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_signalr_service.hcl
@@ -1,6 +1,6 @@
 mapping "azurerm_signalr_service" {
-  import_path = "azure-rest-api-specs/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/signalr.json"
+  import_path = "azure-rest-api-specs/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2023-02-01/signalr.json"
 
-  name                = SignalRServiceName
+  name                = ResourceName
   resource_group_name = ResourceGroupParameter
 }


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-azurerm/releases

## v3.44

- [ ] ~~media - updating to 2022-08-01~~
- [ ] ~~postgres - updating to 2022-12-01~~

## v3.45

No API version updates

## v3.46

- [x] containerservice - updating to 2023-01-02-preview
- [ ] ~~hybridcompute - updating to 2022-11-10~~

## v3.47

 - [x] redis - updating to 2022-06-01

## v3.48

- [x] signalr - updating to 2023-02-01
- [ ] ~~webpubsub - updating to 2023-02-01~~
