### PR TITLE
Fix signing for Cosign v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,8 +24,6 @@ checksum:
   name_template: 'checksums.txt'
 signs:
   - cmd: cosign
-    env:
-    - COSIGN_EXPERIMENTAL=1
     signature: '${artifact}.keyless.sig'
     certificate: '${artifact}.pem'
     output: true
@@ -35,6 +33,7 @@ signs:
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
       - '${artifact}'
+      - --yes
 release:
   github:
     owner: terraform-linters


### PR DESCRIPTION
The `--yes` flag is required for Cosign v2's automated signing process. Also, `COSIGN_EXPERIMENTAL` is no longer required.