### PR TITLE
Bump terraform-provider-azurerm to v3.53.0 from v3.48.0

### DIFF
--- a/docs/rules/azurerm_kubernetes_cluster_invalid_name.md
+++ b/docs/rules/azurerm_kubernetes_cluster_invalid_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-01-02-preview/managedClusters.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-02-02-preview/managedClusters.json

--- a/docs/rules/azurerm_kubernetes_cluster_node_pool_invalid_os_disk_size_gb.md
+++ b/docs/rules/azurerm_kubernetes_cluster_node_pool_invalid_os_disk_size_gb.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-01-02-preview/managedClusters.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-02-02-preview/managedClusters.json

--- a/docs/rules/azurerm_kubernetes_cluster_node_pool_invalid_os_type.md
+++ b/docs/rules/azurerm_kubernetes_cluster_node_pool_invalid_os_type.md
@@ -41,4 +41,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-01-02-preview/managedClusters.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-02-02-preview/managedClusters.json

--- a/docs/rules/azurerm_search_service_invalid_partition_count.md
+++ b/docs/rules/azurerm_search_service_invalid_partition_count.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/search/resource-manager/Microsoft.Search/stable/2020-03-13/search.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/search/resource-manager/Microsoft.Search/stable/2022-09-01/search.json

--- a/docs/rules/azurerm_search_service_invalid_replica_count.md
+++ b/docs/rules/azurerm_search_service_invalid_replica_count.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/search/resource-manager/Microsoft.Search/stable/2020-03-13/search.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/search/resource-manager/Microsoft.Search/stable/2022-09-01/search.json

--- a/docs/rules/azurerm_search_service_invalid_sku.md
+++ b/docs/rules/azurerm_search_service_invalid_sku.md
@@ -46,4 +46,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/search/resource-manager/Microsoft.Search/stable/2020-03-13/search.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/search/resource-manager/Microsoft.Search/stable/2022-09-01/search.json

--- a/tools/apispec-rule-gen/mappings/azurerm_kubernetes_cluster.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_kubernetes_cluster.hcl
@@ -1,9 +1,9 @@
 mapping "azurerm_kubernetes_cluster" {
-  import_path = "azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-01-02-preview/managedClusters.json"
+  import_path = "azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-02-02-preview/managedClusters.json"
 
   name                       = ResourceNameParameter
   resource_group_name        = any //ResourceGroupNameParameter
-  dns_prefix                 = ContainerServiceMasterProfile.dnsPrefix
+  dns_prefix                 = ManagedClusterProperties.dnsPrefix
   enable_pod_security_policy = ManagedClusterProperties.enablePodSecurityPolicy
   kubernetes_version         = ManagedClusterProperties.kubernetesVersion
   node_resource_group        = ManagedClusterProperties.nodeResourceGroup

--- a/tools/apispec-rule-gen/mappings/azurerm_kubernetes_cluster_node_pool.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_kubernetes_cluster_node_pool.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_kubernetes_cluster_node_pool" {
-  import_path = "azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-01-02-preview/managedClusters.json"
+  import_path = "azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-02-02-preview/managedClusters.json"
 
   vm_size               = any //ContainerServiceVMSize
   availability_zones    = ManagedClusterAgentPoolProfileProperties.availabilityZones
@@ -10,5 +10,5 @@ mapping "azurerm_kubernetes_cluster_node_pool" {
   node_taints           = ManagedClusterAgentPoolProfileProperties.nodeTaints
   os_disk_size_gb       = ContainerServiceOSDisk
   os_type               = OSType
-  vnet_subnet_id        = ContainerServiceVnetSubnetID
+  vnet_subnet_id        = any //ContainerServiceVnetSubnetID
 }

--- a/tools/apispec-rule-gen/mappings/azurerm_search_service.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_search_service.hcl
@@ -1,7 +1,7 @@
 mapping "azurerm_search_service" {
-  import_path = "azure-rest-api-specs/specification/search/resource-manager/Microsoft.Search/stable/2020-03-13/search.json"
+  import_path = "azure-rest-api-specs/specification/search/resource-manager/Microsoft.Search/stable/2022-09-01/search.json"
 
-  location            = Resource.location
+  location            = any //Resource.location
   name                = SearchServiceNameParameter
   resource_group_name = ResourceGroupNameParameter
   sku                 = Sku.name


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-azurerm/releases

## v3.49

- [ ] ~~azurerm_media_job, azurerm_media_transform - updating to 2022-07-01~~

## v3.50

No API version updates

## v3.51

- [x] containerservice - updating to 2023-02-02-preview
- [x] search - updating to 2022-09-01
- [ ] ~~batch - updating to 2022-01-01~~

## v3.52

No API version updates

## v3.53

- [ ] ~~hpccache - updating to 2023-01-01~~
- [ ] ~~orbital - updating to 2022-11-01~~
- [ ] ~~vmware - updating to 2022-05-01~~