### PR TITLE
Bump terraform-provider-azurerm to v3.60.0 from v3.53.0

### DIFF
--- a/docs/rules/azurerm_batch_account_invalid_name.md
+++ b/docs/rules/azurerm_batch_account_invalid_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/batch/resource-manager/Microsoft.Batch/stable/2022-01-01/BatchManagement.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/batch/resource-manager/Microsoft.Batch/stable/2022-10-01/BatchManagement.json

--- a/docs/rules/azurerm_batch_account_invalid_pool_allocation_mode.md
+++ b/docs/rules/azurerm_batch_account_invalid_pool_allocation_mode.md
@@ -41,4 +41,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/batch/resource-manager/Microsoft.Batch/stable/2022-01-01/BatchManagement.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/batch/resource-manager/Microsoft.Batch/stable/2022-10-01/BatchManagement.json

--- a/docs/rules/azurerm_batch_application_invalid_account_name.md
+++ b/docs/rules/azurerm_batch_application_invalid_account_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/batch/resource-manager/Microsoft.Batch/stable/2022-01-01/BatchManagement.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/batch/resource-manager/Microsoft.Batch/stable/2022-10-01/BatchManagement.json

--- a/docs/rules/azurerm_batch_application_invalid_name.md
+++ b/docs/rules/azurerm_batch_application_invalid_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/batch/resource-manager/Microsoft.Batch/stable/2022-01-01/BatchManagement.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/batch/resource-manager/Microsoft.Batch/stable/2022-10-01/BatchManagement.json

--- a/docs/rules/azurerm_batch_pool_invalid_account_name.md
+++ b/docs/rules/azurerm_batch_pool_invalid_account_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/batch/resource-manager/Microsoft.Batch/stable/2022-01-01/BatchManagement.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/batch/resource-manager/Microsoft.Batch/stable/2022-10-01/BatchManagement.json

--- a/docs/rules/azurerm_batch_pool_invalid_name.md
+++ b/docs/rules/azurerm_batch_pool_invalid_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/batch/resource-manager/Microsoft.Batch/stable/2022-01-01/BatchManagement.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/batch/resource-manager/Microsoft.Batch/stable/2022-10-01/BatchManagement.json

--- a/docs/rules/azurerm_cosmosdb_cassandra_keyspace_invalid_account_name.md
+++ b/docs/rules/azurerm_cosmosdb_cassandra_keyspace_invalid_account_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json

--- a/docs/rules/azurerm_cosmosdb_cassandra_keyspace_invalid_resource_group_name.md
+++ b/docs/rules/azurerm_cosmosdb_cassandra_keyspace_invalid_resource_group_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json

--- a/docs/rules/azurerm_cosmosdb_gremlin_database_invalid_account_name.md
+++ b/docs/rules/azurerm_cosmosdb_gremlin_database_invalid_account_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json

--- a/docs/rules/azurerm_cosmosdb_gremlin_database_invalid_resource_group_name.md
+++ b/docs/rules/azurerm_cosmosdb_gremlin_database_invalid_resource_group_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json

--- a/docs/rules/azurerm_cosmosdb_gremlin_graph_invalid_account_name.md
+++ b/docs/rules/azurerm_cosmosdb_gremlin_graph_invalid_account_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json

--- a/docs/rules/azurerm_cosmosdb_gremlin_graph_invalid_resource_group_name.md
+++ b/docs/rules/azurerm_cosmosdb_gremlin_graph_invalid_resource_group_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json

--- a/docs/rules/azurerm_cosmosdb_mongo_collection_invalid_resource_group_name.md
+++ b/docs/rules/azurerm_cosmosdb_mongo_collection_invalid_resource_group_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json

--- a/docs/rules/azurerm_cosmosdb_sql_container_invalid_account_name.md
+++ b/docs/rules/azurerm_cosmosdb_sql_container_invalid_account_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json

--- a/docs/rules/azurerm_cosmosdb_sql_container_invalid_resource_group_name.md
+++ b/docs/rules/azurerm_cosmosdb_sql_container_invalid_resource_group_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json

--- a/docs/rules/azurerm_cosmosdb_sql_database_invalid_account_name.md
+++ b/docs/rules/azurerm_cosmosdb_sql_database_invalid_account_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json

--- a/docs/rules/azurerm_cosmosdb_sql_database_invalid_resource_group_name.md
+++ b/docs/rules/azurerm_cosmosdb_sql_database_invalid_resource_group_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json

--- a/docs/rules/azurerm_cosmosdb_table_invalid_account_name.md
+++ b/docs/rules/azurerm_cosmosdb_table_invalid_account_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json

--- a/docs/rules/azurerm_cosmosdb_table_invalid_resource_group_name.md
+++ b/docs/rules/azurerm_cosmosdb_table_invalid_resource_group_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json

--- a/tools/apispec-rule-gen/mappings/azurerm_batch_account.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_batch_account.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_batch_account" {
-  import_path = "azure-rest-api-specs/specification/batch/resource-manager/Microsoft.Batch/stable/2022-01-01/BatchManagement.json"
+  import_path = "azure-rest-api-specs/specification/batch/resource-manager/Microsoft.Batch/stable/2022-10-01/BatchManagement.json"
 
   name                 = AccountNameParameter
   resource_group_name  = ResourceGroupNameParameter

--- a/tools/apispec-rule-gen/mappings/azurerm_batch_application.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_batch_application.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_batch_application" {
-  import_path = "azure-rest-api-specs/specification/batch/resource-manager/Microsoft.Batch/stable/2022-01-01/BatchManagement.json"
+  import_path = "azure-rest-api-specs/specification/batch/resource-manager/Microsoft.Batch/stable/2022-10-01/BatchManagement.json"
 
   name                = ApplicationNameParameter
   resource_group_name = ResourceGroupNameParameter

--- a/tools/apispec-rule-gen/mappings/azurerm_batch_pool.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_batch_pool.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_batch_pool" {
-  import_path = "azure-rest-api-specs/specification/batch/resource-manager/Microsoft.Batch/stable/2022-01-01/BatchManagement.json"
+  import_path = "azure-rest-api-specs/specification/batch/resource-manager/Microsoft.Batch/stable/2022-10-01/BatchManagement.json"
 
   name                = ApplicationNameParameter
   resource_group_name = ResourceGroupNameParameter

--- a/tools/apispec-rule-gen/mappings/azurerm_cosmosdb_cassandra_keyspace.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_cosmosdb_cassandra_keyspace.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_cosmosdb_cassandra_keyspace" {
-  import_path = "azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json"
+  import_path = "azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json"
 
   name                = keyspaceNameParameter
   resource_group_name = resourceGroupNameParameter

--- a/tools/apispec-rule-gen/mappings/azurerm_cosmosdb_gremlin_database.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_cosmosdb_gremlin_database.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_cosmosdb_gremlin_database" {
-  import_path = "azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json"
+  import_path = "azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json"
 
   name                = databaseNameParameter
   resource_group_name = resourceGroupNameParameter

--- a/tools/apispec-rule-gen/mappings/azurerm_cosmosdb_gremlin_graph.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_cosmosdb_gremlin_graph.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_cosmosdb_gremlin_graph" {
-  import_path = "azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json"
+  import_path = "azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json"
 
   name                = graphNameParameter
   resource_group_name = resourceGroupNameParameter

--- a/tools/apispec-rule-gen/mappings/azurerm_cosmosdb_mongo_collection.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_cosmosdb_mongo_collection.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_cosmosdb_mongo_collection" {
-  import_path = "azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json"
+  import_path = "azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json"
 
   name                = collectionNameParameter
   resource_group_name = resourceGroupNameParameter

--- a/tools/apispec-rule-gen/mappings/azurerm_cosmosdb_sql_container.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_cosmosdb_sql_container.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_cosmosdb_sql_container" {
-  import_path = "azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json"
+  import_path = "azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json"
 
   name                = containerNameParameter
   resource_group_name = resourceGroupNameParameter

--- a/tools/apispec-rule-gen/mappings/azurerm_cosmosdb_sql_database.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_cosmosdb_sql_database.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_cosmosdb_sql_database" {
-  import_path = "azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json"
+  import_path = "azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json"
 
   name                = databaseNameParameter
   resource_group_name = resourceGroupNameParameter

--- a/tools/apispec-rule-gen/mappings/azurerm_cosmosdb_table.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_cosmosdb_table.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_cosmosdb_table" {
-  import_path = "azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json"
+  import_path = "azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json"
 
   name                = tableNameParameter
   resource_group_name = resourceGroupNameParameter

--- a/tools/apispec-rule-gen/mappings/azurerm_monitor_autoscale_setting.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_monitor_autoscale_setting.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_monitor_autoscale_setting" {
-  import_path = "azure-rest-api-specs/specification/monitor/resource-manager/Microsoft.Insights/stable/2015-04-01/autoscale_API.json"
+  import_path = "azure-rest-api-specs/specification/monitor/resource-manager/Microsoft.Insights/stable/2022-10-01/autoscale_API.json"
 
   name                = AutoscaleSettingNameParameter
   resource_group_name = any //ResourceGroupNameParameter


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-azurerm/releases

## v3.54

- [ ] ~~security - updating to 2023-01-01~~

## v3.55

- [ ] ~~recoveryservicesbackup - updating to 2023-02-01~~

## v3.56

- [ ] ~~provider: updating to 2022-09-01~~
- [ ] ~~appconfiguration: updating to 2023-03-01~~

## v3.57

No API version updates

## v3.58

- [x] azurerm_monitor_autoscale_setting: updating to 2022-10-01
- [x] cosmosdb: updating to 2023-04-15
- [ ] ~~appplatform: updating to 2023-03-01-preview~~

## v3.59

- [ ] ~~actiongroupsapis: updating to 2023-01-01~~
- [ ] ~~azurerm_monitor_autoscale_setting: updating to 2023-05-01-preview~~

## v3.60

- [x] batch: updating to 2022-10-01
- [ ] ~~loadtest: updating to 2022-12-01~~

