### PR TITLE
idempotent azure-docs watching

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -14,34 +14,11 @@ jobs:
     - name: Calculate diff
       run: |
         curl https://raw.githubusercontent.com/MicrosoftDocs/azure-docs/main/articles/virtual-machines/sizes.md --output .github/snapshots/size.md
-        git diff > snapshot.diff
-    - name: Create an issue
-      uses: actions/github-script@v7
+    - name: Create PR
+      uses: peter-evans/create-pull-request@v6
       with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          const issues = await github.rest.issues.listForRepo({
-            owner: 'terraform-linters',
-            repo: 'tflint-ruleset-azurerm',
-            state: 'open',
-            labels: ['bot']
-          })
-          if (issues.data.length !== 0) {
-            console.log("Issue already opened. Skipped.")
-            return
-          }
-
-          const fs = require('fs')
-          const data = fs.readFileSync('snapshot.diff', 'utf-8')
-          if (data === "") {
-            console.log("No diff. Skipped.")
-            return
-          }
-
-          github.rest.issues.create({
-            owner: 'terraform-linters',
-            repo: 'tflint-ruleset-azurerm',
-            title: '🤖 MicrosoftDocs/azure-docs Changes Report',
-            body: "Changes found from the saved snapshots :eyes:\n\n```diff\n" + data + "```\n\nhttps://github.com/MicrosoftDocs/azure-docs/blob/main/articles/virtual-machines/sizes.md",
-            labels: ['bot'],
-          })
+        title: 🤖 MicrosoftDocs/azure-docs changes
+        commit-message: |
+          Manually edit https://github.com/terraform-linters/tflint-ruleset-azurerm/edit/create-pull-request/patch/rules/utils.go
+          based on https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/virtual-machines/sizes.md
+        delete-branch: true

--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -17,8 +17,9 @@ jobs:
     - name: Create PR
       uses: peter-evans/create-pull-request@v6
       with:
+        branch: azure-docs
         title: 🤖 MicrosoftDocs/azure-docs changes
         commit-message: |
-          Manually edit https://github.com/terraform-linters/tflint-ruleset-azurerm/edit/create-pull-request/patch/rules/utils.go
+          Manually edit https://github.com/terraform-linters/tflint-ruleset-azurerm/edit/azure-docs/rules/utils.go
           based on https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/virtual-machines/sizes.md
         delete-branch: true


### PR DESCRIPTION
Current azure-docs watching isn't idempotent:
https://github.com/terraform-linters/tflint-ruleset-azurerm/blob/47929a7392d601e040eba64bacef67e51e24ebb9/.github/workflows/watch.yml#L29-L30
leaving stale issues: https://github.com/terraform-linters/tflint-ruleset-azurerm/issues/311

---

Using [`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request/) to PR https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/virtual-machines/sizes.md changes