### PR TITLE
Adds a rule to check that the name of a windows virtual machine is valid

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -243,7 +243,7 @@ These are the rules that warn against invalid values generated from [azure-rest-
 |[azurerm_virtual_network_gateway_invalid_type](rules/azurerm_virtual_network_gateway_invalid_type.md)|✔|
 |[azurerm_virtual_network_gateway_invalid_vpn_type](rules/azurerm_virtual_network_gateway_invalid_vpn_type.md)|✔|
 |[azurerm_virtual_wan_invalid_office365_local_breakout_category](rules/azurerm_virtual_wan_invalid_office365_local_breakout_category.md)|✔|
-|[azurerm_windows_virtual_machine_invalid_size](rules/azurerm_windows_virtual_machine_invalid_size.md)|✔|
+|[azurerm_windows_virtual_machine_invalid_name](rules/azurerm_windows_virtual_machine_invalid_name.md)|✔|
 |[azurerm_windows_virtual_machine_invalid_eviction_policy](rules/azurerm_windows_virtual_machine_invalid_eviction_policy.md)|✔|
 |[azurerm_windows_virtual_machine_invalid_priority](rules/azurerm_windows_virtual_machine_invalid_priority.md)|✔|
 |[azurerm_windows_virtual_machine_scale_set_invalid_eviction_policy](rules/azurerm_windows_virtual_machine_scale_set_invalid_eviction_policy.md)|✔|

--- a/docs/README.md
+++ b/docs/README.md
@@ -243,6 +243,7 @@ These are the rules that warn against invalid values generated from [azure-rest-
 |[azurerm_virtual_network_gateway_invalid_type](rules/azurerm_virtual_network_gateway_invalid_type.md)|✔|
 |[azurerm_virtual_network_gateway_invalid_vpn_type](rules/azurerm_virtual_network_gateway_invalid_vpn_type.md)|✔|
 |[azurerm_virtual_wan_invalid_office365_local_breakout_category](rules/azurerm_virtual_wan_invalid_office365_local_breakout_category.md)|✔|
+|[azurerm_windows_virtual_machine_invalid_size](rules/azurerm_windows_virtual_machine_invalid_size.md)|✔|
 |[azurerm_windows_virtual_machine_invalid_eviction_policy](rules/azurerm_windows_virtual_machine_invalid_eviction_policy.md)|✔|
 |[azurerm_windows_virtual_machine_invalid_priority](rules/azurerm_windows_virtual_machine_invalid_priority.md)|✔|
 |[azurerm_windows_virtual_machine_scale_set_invalid_eviction_policy](rules/azurerm_windows_virtual_machine_scale_set_invalid_eviction_policy.md)|✔|

--- a/docs/rules/azurerm_windows_virtual_machine_invalid_name.md
+++ b/docs/rules/azurerm_windows_virtual_machine_invalid_name.md
@@ -1,0 +1,32 @@
+# azurerm_windows_virtual_machine_invalid_name
+
+Warns about values that appear to be invalid based on [Naming rules and restrictions for Azure resources](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcompute).
+
+In this rule, the string must match the regular expression `^[a-zA-Z0-9]{0,1}[a-zA-Z0-9]{0,13}[a-zA-Z0-9]$`.
+
+## Example
+
+```hcl
+resource "azurerm_windows_virtual_machine" "foo" {
+  name = ... // invalid value
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Error: "..." does not match valid pattern ^[a-zA-Z0-9]{0,1}[a-zA-Z0-9]{0,13}[a-zA-Z0-9]$ (azurerm_windows_virtual_machine_invalid_name)
+
+  on template.tf line 2:
+  2:   name = ... // invalid value
+
+```
+
+## Why
+
+Requests containing invalid values will return an error when calling the API by `terraform apply`.
+
+## How To Fix
+
+Replace the warned value with a valid value.

--- a/rules/azurerm_windows_virtual_machine_invalid_name.go
+++ b/rules/azurerm_windows_virtual_machine_invalid_name.go
@@ -45,16 +45,11 @@ func (r *AzurermWindowsVirtualMachineInvalidNameRule) Severity() tflint.Severity
 
 // Link returns the rule reference link
 func (r *AzurermWindowsVirtualMachineInvalidNameRule) Link() string {
-	// TODO: If the rule is so trivial that no documentation is needed, return "" instead.
 	return project.ReferenceLink(r.Name())
 }
 
-// TODO: Write the details of the inspection
 // Check checks the name is valid
 func (r *AzurermWindowsVirtualMachineInvalidNameRule) Check(runner tflint.Runner) error {
-	// TODO: Write the implementation here. See this documentation for what tflint.Runner can do.
-	//       https://pkg.go.dev/github.com/terraform-linters/tflint-plugin-sdk/tflint#Runner
-
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{
 			{Name: r.primaryAttributeName},

--- a/rules/azurerm_windows_virtual_machine_invalid_name.go
+++ b/rules/azurerm_windows_virtual_machine_invalid_name.go
@@ -1,0 +1,95 @@
+package rules
+
+import (
+	"fmt"
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-azurerm/project"
+	"regexp"
+)
+
+// AzurermWindowsVirtualMachineInvalidNameRule checks the hostname is valid
+type AzurermWindowsVirtualMachineInvalidNameRule struct {
+	tflint.DefaultRule
+
+	pattern                *regexp.Regexp
+	resourceType           string
+	primaryAttributeName   string
+	secondaryAttributeName string
+}
+
+// NewAzurermWindowsVirtualMachineInvalidNameRule returns new rule with default attributes
+func NewAzurermWindowsVirtualMachineInvalidNameRule() *AzurermWindowsVirtualMachineInvalidNameRule {
+	return &AzurermWindowsVirtualMachineInvalidNameRule{
+		resourceType:           "azurerm_windows_virtual_machine",
+		primaryAttributeName:   "name",
+		secondaryAttributeName: "computer_name",
+		pattern:                regexp.MustCompile(`^[a-zA-Z0-9]{0,1}[a-zA-Z0-9-]{0,13}[a-zA-Z0-9]$`),
+	}
+}
+
+// Name returns the rule name
+func (r *AzurermWindowsVirtualMachineInvalidNameRule) Name() string {
+	return "azurerm_windows_virtual_machine_invalid_name"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AzurermWindowsVirtualMachineInvalidNameRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AzurermWindowsVirtualMachineInvalidNameRule) Severity() tflint.Severity {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AzurermWindowsVirtualMachineInvalidNameRule) Link() string {
+	// TODO: If the rule is so trivial that no documentation is needed, return "" instead.
+	return project.ReferenceLink(r.Name())
+}
+
+// TODO: Write the details of the inspection
+// Check checks the name is valid
+func (r *AzurermWindowsVirtualMachineInvalidNameRule) Check(runner tflint.Runner) error {
+	// TODO: Write the implementation here. See this documentation for what tflint.Runner can do.
+	//       https://pkg.go.dev/github.com/terraform-linters/tflint-plugin-sdk/tflint#Runner
+
+	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
+		Attributes: []hclext.AttributeSchema{
+			{Name: r.primaryAttributeName},
+			{Name: r.secondaryAttributeName},
+		},
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Blocks {
+		_, exists := resource.Body.Attributes[r.secondaryAttributeName]
+		if exists {
+			continue
+		}
+
+		primaryAttribute, exists := resource.Body.Attributes[r.primaryAttributeName]
+		if !exists {
+			continue
+		}
+
+		err := runner.EvaluateExpr(primaryAttribute.Expr, func(val string) error {
+			if !r.pattern.MatchString(val) {
+				runner.EmitIssue(
+					r,
+					fmt.Sprintf(`"%s" does not match valid pattern %s`, val, `^[a-zA-Z0-9]{0,1}[a-zA-Z0-9]{0,13}[a-zA-Z0-9]$`),
+					primaryAttribute.Expr.Range(),
+				)
+			}
+			return nil
+		}, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/rules/azurerm_windows_virtual_machine_invalid_name_test.go
+++ b/rules/azurerm_windows_virtual_machine_invalid_name_test.go
@@ -1,0 +1,82 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AzurermWindowsVirtualMachineInvalidName(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "InvalidName - Ends with hyphen",
+			Content: `
+resource "azurerm_windows_virtual_machine" "vm" {
+  name = "dummy-"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAzurermWindowsVirtualMachineInvalidNameRule(),
+					Message: `"dummy-" does not match valid pattern ^[a-zA-Z0-9]{0,1}[a-zA-Z0-9]{0,13}[a-zA-Z0-9]$`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 10},
+						End:      hcl.Pos{Line: 3, Column: 18},
+					},
+				},
+			},
+		},
+		{
+			Name: "InvalidName - too long",
+			Content: `
+resource "azurerm_windows_virtual_machine" "vm" {
+  name = "dummyhostname123"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAzurermWindowsVirtualMachineInvalidNameRule(),
+					Message: `"dummyhostname123" does not match valid pattern ^[a-zA-Z0-9]{0,1}[a-zA-Z0-9]{0,13}[a-zA-Z0-9]$`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 10},
+						End:      hcl.Pos{Line: 3, Column: 28},
+					},
+				},
+			},
+		},
+		{
+			Name: "ValidName - Name is valid",
+			Content: `
+resource "azurerm_windows_virtual_machine" "vm" {
+  name = "dummyhostname1"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "ValidName - Hostname is specified",
+			Content: `
+resource "azurerm_windows_virtual_machine" "vm" {
+  name = "dummy-"
+  computer_name = "dummyhostname1"
+}`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAzurermWindowsVirtualMachineInvalidNameRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -15,4 +15,5 @@ var Rules = append([]tflint.Rule{
 	NewAzurermWindowsVirtualMachineInvalidSizeRule(),
 	NewAzurermWindowsVirtualMachineScaleSetInvalidSkuRule(),
 	NewAzurermResourceMissingTagsRule(),
+	NewAzurermWindowsVirtualMachineInvalidNameRule(),
 }, apispec.Rules...)


### PR DESCRIPTION
Hi,

i added the rule `azurerm_windows_virtual_machine_invalid_name`.

It checks, if the name is a valid windows server hostname, based on this documenation:
https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcompute
![image](https://github.com/terraform-linters/tflint-ruleset-azurerm/assets/33316737/01fe1ff8-5445-4441-8677-c0491085b43e)

Based on the terraform documentation, the check is skipped, if the `computer_name`  attribute is specified. In future this rule could be expanded or a second rule specific for `computer_name could be added`.
![image](https://github.com/terraform-linters/tflint-ruleset-azurerm/assets/33316737/2d6df132-0a60-4987-b4d8-38f3f7953096)

Thank you!