### PR TITLE
Adds a rule to check that the name of a windows virtual machine is valid

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -243,6 +243,7 @@ These are the rules that warn against invalid values generated from [azure-rest-
 |[azurerm_virtual_network_gateway_invalid_type](rules/azurerm_virtual_network_gateway_invalid_type.md)|✔|
 |[azurerm_virtual_network_gateway_invalid_vpn_type](rules/azurerm_virtual_network_gateway_invalid_vpn_type.md)|✔|
 |[azurerm_virtual_wan_invalid_office365_local_breakout_category](rules/azurerm_virtual_wan_invalid_office365_local_breakout_category.md)|✔|
+|[azurerm_windows_virtual_machine_invalid_name](rules/azurerm_windows_virtual_machine_invalid_name.md)|✔|
 |[azurerm_windows_virtual_machine_invalid_eviction_policy](rules/azurerm_windows_virtual_machine_invalid_eviction_policy.md)|✔|
 |[azurerm_windows_virtual_machine_invalid_priority](rules/azurerm_windows_virtual_machine_invalid_priority.md)|✔|
 |[azurerm_windows_virtual_machine_scale_set_invalid_eviction_policy](rules/azurerm_windows_virtual_machine_scale_set_invalid_eviction_policy.md)|✔|

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This documentation describes a list of rules available by enabling this ruleset.
 |[azurerm_linux_virtual_machine_scale_set_invalid_sku](rules/azurerm_linux_virtual_machine_scale_set_invalid_sku.md)|✔|
 |[azurerm_resource_missing_tags](rules/azurerm_resource_missing_tags.md)||
 |[azurerm_virtual_machine_invalid_vm_size](rules/azurerm_virtual_machine_invalid_vm_size.md)|✔|
+|[azurerm_windows_virtual_machine_invalid_name](rules/azurerm_windows_virtual_machine_invalid_name.md)|✔|
 |[azurerm_windows_virtual_machine_invalid_size](rules/azurerm_windows_virtual_machine_invalid_size.md)|✔|
 |[azurerm_windows_virtual_machine_scale_set_invalid_sku](rules/azurerm_windows_virtual_machine_scale_set_invalid_sku.md)|✔|
 
@@ -243,7 +244,6 @@ These are the rules that warn against invalid values generated from [azure-rest-
 |[azurerm_virtual_network_gateway_invalid_type](rules/azurerm_virtual_network_gateway_invalid_type.md)|✔|
 |[azurerm_virtual_network_gateway_invalid_vpn_type](rules/azurerm_virtual_network_gateway_invalid_vpn_type.md)|✔|
 |[azurerm_virtual_wan_invalid_office365_local_breakout_category](rules/azurerm_virtual_wan_invalid_office365_local_breakout_category.md)|✔|
-|[azurerm_windows_virtual_machine_invalid_name](rules/azurerm_windows_virtual_machine_invalid_name.md)|✔|
 |[azurerm_windows_virtual_machine_invalid_eviction_policy](rules/azurerm_windows_virtual_machine_invalid_eviction_policy.md)|✔|
 |[azurerm_windows_virtual_machine_invalid_priority](rules/azurerm_windows_virtual_machine_invalid_priority.md)|✔|
 |[azurerm_windows_virtual_machine_scale_set_invalid_eviction_policy](rules/azurerm_windows_virtual_machine_scale_set_invalid_eviction_policy.md)|✔|

--- a/docs/rules/azurerm_windows_virtual_machine_invalid_name.md
+++ b/docs/rules/azurerm_windows_virtual_machine_invalid_name.md
@@ -1,0 +1,32 @@
+# azurerm_windows_virtual_machine_invalid_name
+
+Warns about values that appear to be invalid based on [Naming rules and restrictions for Azure resources](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcompute).
+
+In this rule, the string must match the regular expression `^[a-zA-Z0-9]{0,1}[a-zA-Z0-9]{0,13}[a-zA-Z0-9]$`.
+
+## Example
+
+```hcl
+resource "azurerm_windows_virtual_machine" "foo" {
+  name = ... // invalid value
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Error: "..." does not match valid pattern ^[a-zA-Z0-9]{0,1}[a-zA-Z0-9]{0,13}[a-zA-Z0-9]$ (azurerm_windows_virtual_machine_invalid_name)
+
+  on template.tf line 2:
+  2:   name = ... // invalid value
+
+```
+
+## Why
+
+Requests containing invalid values will return an error when calling the API by `terraform apply`.
+
+## How To Fix
+
+Replace the warned value with a valid value.

--- a/docs/rules/azurerm_windows_virtual_machine_invalid_name.md
+++ b/docs/rules/azurerm_windows_virtual_machine_invalid_name.md
@@ -2,13 +2,13 @@
 
 Warns about values that appear to be invalid based on [Naming rules and restrictions for Azure resources](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcompute).
 
-In this rule, the string must match the regular expression `^[a-zA-Z0-9]{0,1}[a-zA-Z0-9]{0,13}[a-zA-Z0-9]$`.
+In this rule, the string must match the regular expression `^[a-zA-Z0-9]{0,1}[a-zA-Z0-9-]{0,13}[a-zA-Z0-9]$`.
 
 ## Example
 
 ```hcl
 resource "azurerm_windows_virtual_machine" "foo" {
-  name = ... // invalid value
+  name = "dummy-" // invalid value
 }
 ```
 
@@ -16,10 +16,10 @@ resource "azurerm_windows_virtual_machine" "foo" {
 $ tflint
 1 issue(s) found:
 
-Error: "..." does not match valid pattern ^[a-zA-Z0-9]{0,1}[a-zA-Z0-9]{0,13}[a-zA-Z0-9]$ (azurerm_windows_virtual_machine_invalid_name)
+Error: "dummy-" does not match valid pattern ^[a-zA-Z0-9]{0,1}[a-zA-Z0-9-]{0,13}[a-zA-Z0-9]$ (azurerm_windows_virtual_machine_invalid_name)
 
   on template.tf line 2:
-  2:   name = ... // invalid value
+  2:   name = "dummy-" // invalid value
 
 ```
 
@@ -29,4 +29,4 @@ Requests containing invalid values will return an error when calling the API by 
 
 ## How To Fix
 
-Replace the warned value with a valid value.
+Replace the warned value with a valid value. In this example a valid name could be "dummy-1", because it matches the valid pattern ^[a-zA-Z0-9]{0,1}[a-zA-Z0-9-]{0,13}[a-zA-Z0-9]$.

--- a/rules/azurerm_windows_virtual_machine_invalid_name.go
+++ b/rules/azurerm_windows_virtual_machine_invalid_name.go
@@ -1,0 +1,90 @@
+package rules
+
+import (
+	"fmt"
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-azurerm/project"
+	"regexp"
+)
+
+// AzurermWindowsVirtualMachineInvalidNameRule checks the hostname is valid
+type AzurermWindowsVirtualMachineInvalidNameRule struct {
+	tflint.DefaultRule
+
+	pattern               *regexp.Regexp
+	resourceType          string
+	attributeName         string
+	attributeComputerName string
+}
+
+// NewAzurermWindowsVirtualMachineInvalidNameRule returns new rule with default attributes
+func NewAzurermWindowsVirtualMachineInvalidNameRule() *AzurermWindowsVirtualMachineInvalidNameRule {
+	return &AzurermWindowsVirtualMachineInvalidNameRule{
+		resourceType:          "azurerm_windows_virtual_machine",
+		attributeName:         "name",
+		attributeComputerName: "computer_name",
+		pattern:               regexp.MustCompile(`^[a-zA-Z0-9]{0,1}[a-zA-Z0-9-]{0,13}[a-zA-Z0-9]$`),
+	}
+}
+
+// Name returns the rule name
+func (r *AzurermWindowsVirtualMachineInvalidNameRule) Name() string {
+	return "azurerm_windows_virtual_machine_invalid_name"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AzurermWindowsVirtualMachineInvalidNameRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AzurermWindowsVirtualMachineInvalidNameRule) Severity() tflint.Severity {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AzurermWindowsVirtualMachineInvalidNameRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks the name is valid
+func (r *AzurermWindowsVirtualMachineInvalidNameRule) Check(runner tflint.Runner) error {
+	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
+		Attributes: []hclext.AttributeSchema{
+			{Name: r.attributeName},
+			{Name: r.attributeComputerName},
+		},
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Blocks {
+		_, exists := resource.Body.Attributes[r.attributeComputerName]
+		if exists {
+			continue
+		}
+
+		primaryAttribute, exists := resource.Body.Attributes[r.attributeName]
+		if !exists {
+			continue
+		}
+
+		err := runner.EvaluateExpr(primaryAttribute.Expr, func(val string) error {
+			if !r.pattern.MatchString(val) {
+				runner.EmitIssue(
+					r,
+					fmt.Sprintf(`"%s" does not match valid pattern %s`, val, `^[a-zA-Z0-9]{0,1}[a-zA-Z0-9]{0,13}[a-zA-Z0-9]$`),
+					primaryAttribute.Expr.Range(),
+				)
+			}
+			return nil
+		}, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/rules/azurerm_windows_virtual_machine_invalid_name.go
+++ b/rules/azurerm_windows_virtual_machine_invalid_name.go
@@ -75,7 +75,7 @@ func (r *AzurermWindowsVirtualMachineInvalidNameRule) Check(runner tflint.Runner
 			if !r.pattern.MatchString(val) {
 				runner.EmitIssue(
 					r,
-					fmt.Sprintf(`"%s" does not match valid pattern %s`, val, `^[a-zA-Z0-9]{0,1}[a-zA-Z0-9]{0,13}[a-zA-Z0-9]$`),
+					fmt.Sprintf(`"%s" does not match valid pattern %s`, val, `^[a-zA-Z0-9]{0,1}[a-zA-Z0-9-]{0,13}[a-zA-Z0-9]$`),
 					primaryAttribute.Expr.Range(),
 				)
 			}

--- a/rules/azurerm_windows_virtual_machine_invalid_name_test.go
+++ b/rules/azurerm_windows_virtual_machine_invalid_name_test.go
@@ -1,0 +1,82 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AzurermWindowsVirtualMachineInvalidName(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "InvalidName - Ends with hyphen",
+			Content: `
+resource "azurerm_windows_virtual_machine" "vm" {
+  name = "dummy-"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAzurermWindowsVirtualMachineInvalidNameRule(),
+					Message: `"dummy-" does not match valid pattern ^[a-zA-Z0-9]{0,1}[a-zA-Z0-9]{0,13}[a-zA-Z0-9]$`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 10},
+						End:      hcl.Pos{Line: 3, Column: 18},
+					},
+				},
+			},
+		},
+		{
+			Name: "InvalidName - too long",
+			Content: `
+resource "azurerm_windows_virtual_machine" "vm" {
+  name = "dummyhostname123"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAzurermWindowsVirtualMachineInvalidNameRule(),
+					Message: `"dummyhostname123" does not match valid pattern ^[a-zA-Z0-9]{0,1}[a-zA-Z0-9]{0,13}[a-zA-Z0-9]$`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 10},
+						End:      hcl.Pos{Line: 3, Column: 28},
+					},
+				},
+			},
+		},
+		{
+			Name: "ValidName - Name is valid",
+			Content: `
+resource "azurerm_windows_virtual_machine" "vm" {
+  name = "dummyhostname1"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "ValidName - Hostname is specified",
+			Content: `
+resource "azurerm_windows_virtual_machine" "vm" {
+  name = "dummy-"
+  computer_name = "dummyhostname1"
+}`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAzurermWindowsVirtualMachineInvalidNameRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/azurerm_windows_virtual_machine_invalid_name_test.go
+++ b/rules/azurerm_windows_virtual_machine_invalid_name_test.go
@@ -22,7 +22,7 @@ resource "azurerm_windows_virtual_machine" "vm" {
 			Expected: helper.Issues{
 				{
 					Rule:    NewAzurermWindowsVirtualMachineInvalidNameRule(),
-					Message: `"dummy-" does not match valid pattern ^[a-zA-Z0-9]{0,1}[a-zA-Z0-9]{0,13}[a-zA-Z0-9]$`,
+					Message: `"dummy-" does not match valid pattern ^[a-zA-Z0-9]{0,1}[a-zA-Z0-9-]{0,13}[a-zA-Z0-9]$`,
 					Range: hcl.Range{
 						Filename: "resource.tf",
 						Start:    hcl.Pos{Line: 3, Column: 10},
@@ -40,7 +40,7 @@ resource "azurerm_windows_virtual_machine" "vm" {
 			Expected: helper.Issues{
 				{
 					Rule:    NewAzurermWindowsVirtualMachineInvalidNameRule(),
-					Message: `"dummyhostname123" does not match valid pattern ^[a-zA-Z0-9]{0,1}[a-zA-Z0-9]{0,13}[a-zA-Z0-9]$`,
+					Message: `"dummyhostname123" does not match valid pattern ^[a-zA-Z0-9]{0,1}[a-zA-Z0-9-]{0,13}[a-zA-Z0-9]$`,
 					Range: hcl.Range{
 						Filename: "resource.tf",
 						Start:    hcl.Pos{Line: 3, Column: 10},

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -12,6 +12,7 @@ var Rules = append([]tflint.Rule{
 	NewAzurermLinuxVirtualMachineInvalidSizeRule(),
 	NewAzurermLinuxVirtualMachineScaleSetInvalidSkuRule(),
 	NewAzurermVirtualMachineInvalidVMSizeRule(),
+	NewAzurermWindowsVirtualMachineInvalidNameRule(),
 	NewAzurermWindowsVirtualMachineInvalidSizeRule(),
 	NewAzurermWindowsVirtualMachineScaleSetInvalidSkuRule(),
 	NewAzurermResourceMissingTagsRule(),

--- a/tools/apispec-rule-gen/doc_README.md.tmpl
+++ b/tools/apispec-rule-gen/doc_README.md.tmpl
@@ -10,6 +10,7 @@ This documentation describes a list of rules available by enabling this ruleset.
 |[azurerm_linux_virtual_machine_scale_set_invalid_sku](rules/azurerm_linux_virtual_machine_scale_set_invalid_sku.md)|✔|
 |[azurerm_resource_missing_tags](rules/azurerm_resource_missing_tags.md)||
 |[azurerm_virtual_machine_invalid_vm_size](rules/azurerm_virtual_machine_invalid_vm_size.md)|✔|
+|[azurerm_windows_virtual_machine_invalid_name](rules/azurerm_windows_virtual_machine_invalid_name.md)|✔|
 |[azurerm_windows_virtual_machine_invalid_size](rules/azurerm_windows_virtual_machine_invalid_size.md)|✔|
 |[azurerm_windows_virtual_machine_scale_set_invalid_sku](rules/azurerm_windows_virtual_machine_scale_set_invalid_sku.md)|✔|
 

--- a/tools/apispec-rule-gen/mappings/azurerm_windows_virtual_machine.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_windows_virtual_machine.hcl
@@ -4,6 +4,7 @@ mapping "azurerm_windows_virtual_machine" {
   admin_password             = any //OSProfile.adminPassword
   admin_username             = any //OSProfile.adminUsername
   size                       = any //HardwareProfile.vmSize
+  name                       = any
   allow_extension_operations = OSProfile.allowExtensionOperations
   computer_name              = OSProfile.computerName
   custom_data                = OSProfile.customData


### PR DESCRIPTION
Hi,

i added the rule `azurerm_windows_virtual_machine_invalid_name`.

It checks, if the name is a valid windows server hostname, based on this documenation:
https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcompute
![image](https://github.com/terraform-linters/tflint-ruleset-azurerm/assets/33316737/01fe1ff8-5445-4441-8677-c0491085b43e)

Based on the terraform documentation, the check is skipped, if the `computer_name`  attribute is specified. In future this rule could be expanded or a second rule specific for `computer_name could be added`.
![image](https://github.com/terraform-linters/tflint-ruleset-azurerm/assets/33316737/2d6df132-0a60-4987-b4d8-38f3f7953096)

Thank you!