### PR TITLE
Bump API versions

### DIFF
--- a/docs/rules/azurerm_application_insights_web_test_invalid_kind.md
+++ b/docs/rules/azurerm_application_insights_web_test_invalid_kind.md
@@ -7,6 +7,7 @@ Warns about values that appear to be invalid based on [azure-rest-api-specs](htt
 Allowed values are:
 - ping
 - multistep
+- standard
 
 ## Example
 
@@ -41,4 +42,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2015-05-01/webTests_API.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2022-06-15/webTests_API.json

--- a/docs/rules/azurerm_bot_channel_email_invalid_bot_name.md
+++ b/docs/rules/azurerm_bot_channel_email_invalid_bot_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/botservice/resource-manager/Microsoft.BotService/preview/2021-05-01-preview/botservice.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/botservice/resource-manager/Microsoft.BotService/stable/2022-09-15/botservice.json

--- a/docs/rules/azurerm_bot_channel_email_invalid_resource_group_name.md
+++ b/docs/rules/azurerm_bot_channel_email_invalid_resource_group_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/botservice/resource-manager/Microsoft.BotService/preview/2021-05-01-preview/botservice.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/botservice/resource-manager/Microsoft.BotService/stable/2022-09-15/botservice.json

--- a/docs/rules/azurerm_database_migration_project_invalid_source_platform.md
+++ b/docs/rules/azurerm_database_migration_project_invalid_source_platform.md
@@ -6,6 +6,9 @@ Warns about values that appear to be invalid based on [azure-rest-api-specs](htt
 
 Allowed values are:
 - SQL
+- MySQL
+- PostgreSql
+- MongoDb
 - Unknown
 
 ## Example
@@ -41,4 +44,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/datamigration/resource-manager/Microsoft.DataMigration/stable/2018-04-19/definitions/Projects.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/datamigration/resource-manager/Microsoft.DataMigration/stable/2021-06-30/definitions/Projects.json

--- a/docs/rules/azurerm_database_migration_project_invalid_target_platform.md
+++ b/docs/rules/azurerm_database_migration_project_invalid_target_platform.md
@@ -6,6 +6,10 @@ Warns about values that appear to be invalid based on [azure-rest-api-specs](htt
 
 Allowed values are:
 - SQLDB
+- SQLMI
+- AzureDbForMySql
+- AzureDbForPostgreSql
+- MongoDb
 - Unknown
 
 ## Example
@@ -41,4 +45,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/datamigration/resource-manager/Microsoft.DataMigration/stable/2018-04-19/definitions/Projects.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/datamigration/resource-manager/Microsoft.DataMigration/stable/2021-06-30/definitions/Projects.json

--- a/docs/rules/azurerm_dedicated_host_group_invalid_platform_fault_domain_count.md
+++ b/docs/rules/azurerm_dedicated_host_group_invalid_platform_fault_domain_count.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/dedicatedHost.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/dedicatedHost.json

--- a/docs/rules/azurerm_dedicated_host_invalid_license_type.md
+++ b/docs/rules/azurerm_dedicated_host_invalid_license_type.md
@@ -42,4 +42,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/dedicatedHost.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/dedicatedHost.json

--- a/docs/rules/azurerm_dedicated_host_invalid_platform_fault_domain.md
+++ b/docs/rules/azurerm_dedicated_host_invalid_platform_fault_domain.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/dedicatedHost.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/dedicatedHost.json

--- a/docs/rules/azurerm_firewall_application_rule_collection_invalid_action.md
+++ b/docs/rules/azurerm_firewall_application_rule_collection_invalid_action.md
@@ -41,4 +41,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/azureFirewall.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/azureFirewall.json

--- a/docs/rules/azurerm_firewall_application_rule_collection_invalid_priority.md
+++ b/docs/rules/azurerm_firewall_application_rule_collection_invalid_priority.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/azureFirewall.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/azureFirewall.json

--- a/docs/rules/azurerm_firewall_nat_rule_collection_invalid_action.md
+++ b/docs/rules/azurerm_firewall_nat_rule_collection_invalid_action.md
@@ -41,4 +41,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/azureFirewall.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/azureFirewall.json

--- a/docs/rules/azurerm_firewall_nat_rule_collection_invalid_priority.md
+++ b/docs/rules/azurerm_firewall_nat_rule_collection_invalid_priority.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/azureFirewall.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/azureFirewall.json

--- a/docs/rules/azurerm_firewall_network_rule_collection_invalid_action.md
+++ b/docs/rules/azurerm_firewall_network_rule_collection_invalid_action.md
@@ -41,4 +41,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/azureFirewall.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/azureFirewall.json

--- a/docs/rules/azurerm_firewall_network_rule_collection_invalid_priority.md
+++ b/docs/rules/azurerm_firewall_network_rule_collection_invalid_priority.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/azureFirewall.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/azureFirewall.json

--- a/docs/rules/azurerm_kubernetes_cluster_invalid_name.md
+++ b/docs/rules/azurerm_kubernetes_cluster_invalid_name.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-06-02-preview/managedClusters.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-09-02-preview/managedClusters.json

--- a/docs/rules/azurerm_kubernetes_cluster_node_pool_invalid_os_disk_size_gb.md
+++ b/docs/rules/azurerm_kubernetes_cluster_node_pool_invalid_os_disk_size_gb.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-06-02-preview/managedClusters.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-09-02-preview/managedClusters.json

--- a/docs/rules/azurerm_kubernetes_cluster_node_pool_invalid_os_type.md
+++ b/docs/rules/azurerm_kubernetes_cluster_node_pool_invalid_os_type.md
@@ -41,4 +41,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-06-02-preview/managedClusters.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-09-02-preview/managedClusters.json

--- a/docs/rules/azurerm_maintenance_configuration_invalid_scope.md
+++ b/docs/rules/azurerm_maintenance_configuration_invalid_scope.md
@@ -46,4 +46,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/maintenance/resource-manager/Microsoft.Maintenance/preview/2022-07-01-preview/Maintenance.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/maintenance/resource-manager/Microsoft.Maintenance/stable/2023-04-01/Maintenance.json

--- a/docs/rules/azurerm_maps_account_invalid_sku_name.md
+++ b/docs/rules/azurerm_maps_account_invalid_sku_name.md
@@ -42,4 +42,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/maps/resource-manager/Microsoft.Maps/stable/2021-02-01/maps-management.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/maps/resource-manager/Microsoft.Maps/stable/2023-06-01/maps-management.json

--- a/docs/rules/azurerm_nat_gateway_invalid_sku_name.md
+++ b/docs/rules/azurerm_nat_gateway_invalid_sku_name.md
@@ -40,4 +40,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/natGateway.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/natGateway.json

--- a/docs/rules/azurerm_network_packet_capture_invalid_maximum_capture_duration.md
+++ b/docs/rules/azurerm_network_packet_capture_invalid_maximum_capture_duration.md
@@ -39,4 +39,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/networkWatcher.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/networkWatcher.json

--- a/docs/rules/azurerm_network_security_rule_invalid_access.md
+++ b/docs/rules/azurerm_network_security_rule_invalid_access.md
@@ -41,4 +41,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/networkSecurityGroup.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/networkSecurityGroup.json

--- a/docs/rules/azurerm_network_security_rule_invalid_direction.md
+++ b/docs/rules/azurerm_network_security_rule_invalid_direction.md
@@ -41,4 +41,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/networkSecurityGroup.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/networkSecurityGroup.json

--- a/docs/rules/azurerm_network_security_rule_invalid_protocol.md
+++ b/docs/rules/azurerm_network_security_rule_invalid_protocol.md
@@ -45,4 +45,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/networkSecurityGroup.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/networkSecurityGroup.json

--- a/docs/rules/azurerm_public_ip_invalid_sku.md
+++ b/docs/rules/azurerm_public_ip_invalid_sku.md
@@ -41,4 +41,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/publicIpAddress.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/publicIpAddress.json

--- a/docs/rules/azurerm_public_ip_prefix_invalid_sku.md
+++ b/docs/rules/azurerm_public_ip_prefix_invalid_sku.md
@@ -40,4 +40,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/publicIpPrefix.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/publicIpPrefix.json

--- a/docs/rules/azurerm_route_invalid_next_hop_type.md
+++ b/docs/rules/azurerm_route_invalid_next_hop_type.md
@@ -44,4 +44,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/routeTable.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/routeTable.json

--- a/docs/rules/azurerm_virtual_machine_data_disk_attachment_invalid_caching.md
+++ b/docs/rules/azurerm_virtual_machine_data_disk_attachment_invalid_caching.md
@@ -42,4 +42,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/computeRPCommon.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/computeRPCommon.json

--- a/docs/rules/azurerm_virtual_machine_data_disk_attachment_invalid_create_option.md
+++ b/docs/rules/azurerm_virtual_machine_data_disk_attachment_invalid_create_option.md
@@ -8,6 +8,8 @@ Allowed values are:
 - FromImage
 - Empty
 - Attach
+- Copy
+- Restore
 
 ## Example
 
@@ -42,4 +44,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/computeRPCommon.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/computeRPCommon.json

--- a/docs/rules/azurerm_virtual_machine_scale_set_invalid_eviction_policy.md
+++ b/docs/rules/azurerm_virtual_machine_scale_set_invalid_eviction_policy.md
@@ -41,4 +41,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/computeRPCommon.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/computeRPCommon.json

--- a/docs/rules/azurerm_virtual_machine_scale_set_invalid_priority.md
+++ b/docs/rules/azurerm_virtual_machine_scale_set_invalid_priority.md
@@ -42,4 +42,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/computeRPCommon.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/computeRPCommon.json

--- a/docs/rules/azurerm_virtual_network_gateway_connection_invalid_connection_protocol.md
+++ b/docs/rules/azurerm_virtual_network_gateway_connection_invalid_connection_protocol.md
@@ -41,4 +41,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/virtualNetworkGateway.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualNetworkGateway.json

--- a/docs/rules/azurerm_virtual_network_gateway_connection_invalid_type.md
+++ b/docs/rules/azurerm_virtual_network_gateway_connection_invalid_type.md
@@ -43,4 +43,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/virtualNetworkGateway.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualNetworkGateway.json

--- a/docs/rules/azurerm_virtual_network_gateway_invalid_generation.md
+++ b/docs/rules/azurerm_virtual_network_gateway_invalid_generation.md
@@ -42,4 +42,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/virtualNetworkGateway.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualNetworkGateway.json

--- a/docs/rules/azurerm_virtual_network_gateway_invalid_sku.md
+++ b/docs/rules/azurerm_virtual_network_gateway_invalid_sku.md
@@ -22,6 +22,7 @@ Allowed values are:
 - ErGw1AZ
 - ErGw2AZ
 - ErGw3AZ
+- ErGwScale
 
 ## Example
 
@@ -56,4 +57,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/virtualNetworkGateway.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualNetworkGateway.json

--- a/docs/rules/azurerm_virtual_network_gateway_invalid_type.md
+++ b/docs/rules/azurerm_virtual_network_gateway_invalid_type.md
@@ -42,4 +42,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/virtualNetworkGateway.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualNetworkGateway.json

--- a/docs/rules/azurerm_virtual_network_gateway_invalid_vpn_type.md
+++ b/docs/rules/azurerm_virtual_network_gateway_invalid_vpn_type.md
@@ -41,4 +41,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/virtualNetworkGateway.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualNetworkGateway.json

--- a/docs/rules/azurerm_virtual_wan_invalid_office365_local_breakout_category.md
+++ b/docs/rules/azurerm_virtual_wan_invalid_office365_local_breakout_category.md
@@ -43,4 +43,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/virtualWan.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualWan.json

--- a/docs/rules/azurerm_windows_virtual_machine_invalid_eviction_policy.md
+++ b/docs/rules/azurerm_windows_virtual_machine_invalid_eviction_policy.md
@@ -41,4 +41,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/computeRPCommon.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/computeRPCommon.json

--- a/docs/rules/azurerm_windows_virtual_machine_invalid_priority.md
+++ b/docs/rules/azurerm_windows_virtual_machine_invalid_priority.md
@@ -42,4 +42,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/computeRPCommon.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/computeRPCommon.json

--- a/docs/rules/azurerm_windows_virtual_machine_scale_set_invalid_eviction_policy.md
+++ b/docs/rules/azurerm_windows_virtual_machine_scale_set_invalid_eviction_policy.md
@@ -41,4 +41,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/computeRPCommon.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/computeRPCommon.json

--- a/docs/rules/azurerm_windows_virtual_machine_scale_set_invalid_priority.md
+++ b/docs/rules/azurerm_windows_virtual_machine_scale_set_invalid_priority.md
@@ -42,4 +42,4 @@ Replace the warned value with a valid value.
 
 This rule is automatically generated from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs). If you are uncertain about the warning, check the following API schema referenced by this rule.
 
-https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/computeRPCommon.json
+https://github.com/Azure/azure-rest-api-specs/tree/master/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/computeRPCommon.json

--- a/rules/apispec/azurerm_application_insights_web_test_invalid_kind.go
+++ b/rules/apispec/azurerm_application_insights_web_test_invalid_kind.go
@@ -27,6 +27,7 @@ func NewAzurermApplicationInsightsWebTestInvalidKindRule() *AzurermApplicationIn
 		enum: []string{
 			"ping",
 			"multistep",
+			"standard",
 		},
 	}
 }

--- a/rules/apispec/azurerm_database_migration_project_invalid_source_platform.go
+++ b/rules/apispec/azurerm_database_migration_project_invalid_source_platform.go
@@ -26,6 +26,9 @@ func NewAzurermDatabaseMigrationProjectInvalidSourcePlatformRule() *AzurermDatab
 		attributeName: "source_platform",
 		enum: []string{
 			"SQL",
+			"MySQL",
+			"PostgreSql",
+			"MongoDb",
 			"Unknown",
 		},
 	}

--- a/rules/apispec/azurerm_database_migration_project_invalid_target_platform.go
+++ b/rules/apispec/azurerm_database_migration_project_invalid_target_platform.go
@@ -26,6 +26,10 @@ func NewAzurermDatabaseMigrationProjectInvalidTargetPlatformRule() *AzurermDatab
 		attributeName: "target_platform",
 		enum: []string{
 			"SQLDB",
+			"SQLMI",
+			"AzureDbForMySql",
+			"AzureDbForPostgreSql",
+			"MongoDb",
 			"Unknown",
 		},
 	}

--- a/rules/apispec/azurerm_virtual_machine_data_disk_attachment_invalid_create_option.go
+++ b/rules/apispec/azurerm_virtual_machine_data_disk_attachment_invalid_create_option.go
@@ -28,6 +28,8 @@ func NewAzurermVirtualMachineDataDiskAttachmentInvalidCreateOptionRule() *Azurer
 			"FromImage",
 			"Empty",
 			"Attach",
+			"Copy",
+			"Restore",
 		},
 	}
 }

--- a/rules/apispec/azurerm_virtual_network_gateway_invalid_sku.go
+++ b/rules/apispec/azurerm_virtual_network_gateway_invalid_sku.go
@@ -42,6 +42,7 @@ func NewAzurermVirtualNetworkGatewayInvalidSkuRule() *AzurermVirtualNetworkGatew
 			"ErGw1AZ",
 			"ErGw2AZ",
 			"ErGw3AZ",
+			"ErGwScale",
 		},
 	}
 }

--- a/tools/apispec-rule-gen/mappings/azurerm_application_insights_web_test.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_application_insights_web_test.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_application_insights_web_test" {
-  import_path = "azure-rest-api-specs/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2015-05-01/webTests_API.json"
+  import_path = "azure-rest-api-specs/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2022-06-15/webTests_API.json"
 
   kind = WebTestProperties.Kind
 }

--- a/tools/apispec-rule-gen/mappings/azurerm_availability_set.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_availability_set.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_availability_set" {
-  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/availabilitySet.json"
+  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/availabilitySet.json"
 
   platform_update_domain_count = AvailabilitySetProperties.platformUpdateDomainCount
   platform_fault_domain_count  = AvailabilitySetProperties.platformFaultDomainCount

--- a/tools/apispec-rule-gen/mappings/azurerm_bastion_host.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_bastion_host.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_bastion_host" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/bastionHost.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/bastionHost.json"
 
   name                = BastionHostName
   resource_group_name = ResourceGroupName

--- a/tools/apispec-rule-gen/mappings/azurerm_bot_channel_email.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_bot_channel_email.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_bot_channel_email" {
-  import_path = "azure-rest-api-specs/specification/botservice/resource-manager/Microsoft.BotService/preview/2021-05-01-preview/botservice.json"
+  import_path = "azure-rest-api-specs/specification/botservice/resource-manager/Microsoft.BotService/stable/2022-09-15/botservice.json"
 
   resource_group_name = resourceGroupNameParameter
   bot_name            = resourceNameParameter

--- a/tools/apispec-rule-gen/mappings/azurerm_database_migration_project.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_database_migration_project.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_database_migration_project" {
-  import_path = "azure-rest-api-specs/specification/datamigration/resource-manager/Microsoft.DataMigration/stable/2018-04-19/definitions/Projects.json"
+  import_path = "azure-rest-api-specs/specification/datamigration/resource-manager/Microsoft.DataMigration/stable/2021-06-30/definitions/Projects.json"
 
   source_platform = ProjectSourcePlatform
   target_platform = ProjectTargetPlatform

--- a/tools/apispec-rule-gen/mappings/azurerm_database_migration_service.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_database_migration_service.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_database_migration_service" {
-  import_path = "azure-rest-api-specs/specification/datamigration/resource-manager/Microsoft.DataMigration/stable/2018-04-19/definitions/Services.json"
+  import_path = "azure-rest-api-specs/specification/datamigration/resource-manager/Microsoft.DataMigration/stable/2021-06-30/definitions/Services.json"
 
   subnet_id = DataMigrationServiceProperties.virtualSubnetId
   sku_name  = ServiceSku.name

--- a/tools/apispec-rule-gen/mappings/azurerm_dedicated_host.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_dedicated_host.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_dedicated_host" {
-  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/dedicatedHost.json"
+  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/dedicatedHost.json"
 
   sku_name                = any //Sku.name
   platform_fault_domain   = DedicatedHostProperties.platformFaultDomain

--- a/tools/apispec-rule-gen/mappings/azurerm_dedicated_host_group.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_dedicated_host_group.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_dedicated_host_group" {
-  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/dedicatedHost.json"
+  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/dedicatedHost.json"
 
   platform_fault_domain_count = DedicatedHostGroupProperties.platformFaultDomainCount
   zones                       = DedicatedHostGroup.zones

--- a/tools/apispec-rule-gen/mappings/azurerm_firewall.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_firewall.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_firewall" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/azureFirewall.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/azureFirewall.json"
 
   zones = AzureFirewall.zones
 }

--- a/tools/apispec-rule-gen/mappings/azurerm_firewall_application_rule_collection.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_firewall_application_rule_collection.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_firewall_application_rule_collection" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/azureFirewall.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/azureFirewall.json"
 
   priority = AzureFirewallApplicationRuleCollectionPropertiesFormat.priority
   action   = AzureFirewallRCActionType

--- a/tools/apispec-rule-gen/mappings/azurerm_firewall_nat_rule_collection.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_firewall_nat_rule_collection.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_firewall_nat_rule_collection" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/azureFirewall.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/azureFirewall.json"
 
   priority = AzureFirewallNatRuleCollectionProperties.priority
   action   = AzureFirewallNatRCActionType

--- a/tools/apispec-rule-gen/mappings/azurerm_firewall_network_rule_collection.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_firewall_network_rule_collection.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_firewall_network_rule_collection" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/azureFirewall.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/azureFirewall.json"
 
   priority = AzureFirewallNetworkRuleCollectionPropertiesFormat.priority
   action   = AzureFirewallRCActionType

--- a/tools/apispec-rule-gen/mappings/azurerm_kubernetes_cluster.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_kubernetes_cluster.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_kubernetes_cluster" {
-  import_path = "azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-06-02-preview/managedClusters.json"
+  import_path = "azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-09-02-preview/managedClusters.json"
 
   name                       = ResourceNameParameter
   resource_group_name        = any //ResourceGroupNameParameter

--- a/tools/apispec-rule-gen/mappings/azurerm_kubernetes_cluster_node_pool.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_kubernetes_cluster_node_pool.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_kubernetes_cluster_node_pool" {
-  import_path = "azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-06-02-preview/managedClusters.json"
+  import_path = "azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-09-02-preview/managedClusters.json"
 
   vm_size               = any //ContainerServiceVMSize
   availability_zones    = ManagedClusterAgentPoolProfileProperties.availabilityZones

--- a/tools/apispec-rule-gen/mappings/azurerm_local_network_gateway.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_local_network_gateway.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_local_network_gateway" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/virtualNetworkGateway.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualNetworkGateway.json"
 
   gateway_address = LocalNetworkGatewayPropertiesFormat.gatewayIpAddress
 }

--- a/tools/apispec-rule-gen/mappings/azurerm_maintenance_configuration.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_maintenance_configuration.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_maintenance_configuration" {
-  import_path = "azure-rest-api-specs/specification/maintenance/resource-manager/Microsoft.Maintenance/preview/2022-07-01-preview/Maintenance.json"
+  import_path = "azure-rest-api-specs/specification/maintenance/resource-manager/Microsoft.Maintenance/stable/2023-04-01/Maintenance.json"
 
   location = MaintenanceConfiguration.location
   scope    = MaintenanceConfigurationProperties.maintenanceScope

--- a/tools/apispec-rule-gen/mappings/azurerm_maps_account.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_maps_account.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_maps_account" {
-  import_path = "azure-rest-api-specs/specification/maps/resource-manager/Microsoft.Maps/stable/2021-02-01/maps-management.json"
+  import_path = "azure-rest-api-specs/specification/maps/resource-manager/Microsoft.Maps/stable/2023-06-01/maps-management.json"
 
   name                = AccountNameParameter
   resource_group_name = any //ResourceGroupNameParameter

--- a/tools/apispec-rule-gen/mappings/azurerm_nat_gateway.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_nat_gateway.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_nat_gateway" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/natGateway.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/natGateway.json"
 
   idle_timeout_in_minutes = NatGatewayPropertiesFormat.idleTimeoutInMinutes
   public_ip_address_ids   = NatGatewayPropertiesFormat.publicIpAddresses

--- a/tools/apispec-rule-gen/mappings/azurerm_network_interface.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_network_interface.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_network_interface" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/networkInterface.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/networkInterface.json"
 
   dns_servers                   = NetworkInterfaceDnsSettings.dnsServers
   enable_ip_forwarding          = NetworkInterfacePropertiesFormat.enableIPForwarding

--- a/tools/apispec-rule-gen/mappings/azurerm_network_packet_capture.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_network_packet_capture.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_network_packet_capture" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/networkWatcher.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/networkWatcher.json"
 
   target_resource_id        = PacketCaptureParameters.target
   maximum_bytes_per_packet  = any //PacketCaptureParameters.bytesToCapturePerPacket

--- a/tools/apispec-rule-gen/mappings/azurerm_network_security_rule.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_network_security_rule.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_network_security_rule" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/networkSecurityGroup.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/networkSecurityGroup.json"
 
   description                                = SecurityRulePropertiesFormat.description
   protocol                                   = SecurityRulePropertiesFormat.protocol

--- a/tools/apispec-rule-gen/mappings/azurerm_network_watcher_flow_log.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_network_watcher_flow_log.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_network_watcher_flow_log" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/networkWatcher.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/networkWatcher.json"
 
   network_security_group_id = FlowLogPropertiesFormat.targetResourceId
   storage_account_id        = FlowLogPropertiesFormat.storageId

--- a/tools/apispec-rule-gen/mappings/azurerm_point_to_site_vpn_gateway.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_point_to_site_vpn_gateway.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_point_to_site_vpn_gateway" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/virtualWan.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualWan.json"
 
   scale_unit = P2SVpnGatewayProperties.vpnGatewayScaleUnit
 }

--- a/tools/apispec-rule-gen/mappings/azurerm_private_link_service.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_private_link_service.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_private_link_service" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/privateLinkService.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/privateLinkService.json"
 
   load_balancer_frontend_ip_configuration_ids = PrivateLinkServiceProperties.loadBalancerFrontendIpConfigurations
   enable_proxy_protocol                       = PrivateLinkServiceProperties.enableProxyProtocol

--- a/tools/apispec-rule-gen/mappings/azurerm_public_ip.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_public_ip.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_public_ip" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/publicIpAddress.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/publicIpAddress.json"
 
   sku                     = PublicIPAddressSku.name
   idle_timeout_in_minutes = PublicIPAddressPropertiesFormat.idleTimeoutInMinutes

--- a/tools/apispec-rule-gen/mappings/azurerm_public_ip_prefix.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_public_ip_prefix.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_public_ip_prefix" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/publicIpPrefix.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/publicIpPrefix.json"
 
   sku           = PublicIPPrefixSku.name
   prefix_length = PublicIPPrefixPropertiesFormat.prefixLength

--- a/tools/apispec-rule-gen/mappings/azurerm_route.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_route.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_route" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/routeTable.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/routeTable.json"
 
   address_prefix         = RoutePropertiesFormat.addressPrefix
   next_hop_type          = RouteNextHopType

--- a/tools/apispec-rule-gen/mappings/azurerm_route_table.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_route_table.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_route_table" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/routeTable.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/routeTable.json"
 
   disable_bgp_route_propagation = RouteTablePropertiesFormat.disableBgpRoutePropagation
 }

--- a/tools/apispec-rule-gen/mappings/azurerm_subnet.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_subnet.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_subnet" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/virtualNetwork.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualNetwork.json"
 
   name              = Subnet.name
   address_prefix    = SubnetPropertiesFormat.addressPrefix

--- a/tools/apispec-rule-gen/mappings/azurerm_virtual_hub.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_virtual_hub.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_virtual_hub" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/virtualWan.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualWan.json"
 
   address_prefix = VirtualHubProperties.addressPrefix
 }

--- a/tools/apispec-rule-gen/mappings/azurerm_virtual_hub_connection.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_virtual_hub_connection.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_virtual_hub_connection" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/virtualWan.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualWan.json"
 
   hub_to_vitual_network_traffic_allowed          = HubVirtualNetworkConnectionProperties.allowHubToRemoteVnetTransit
   vitual_network_to_hub_gateways_traffic_allowed = HubVirtualNetworkConnectionProperties.allowRemoteVnetToUseHubVnetGateways

--- a/tools/apispec-rule-gen/mappings/azurerm_virtual_machine.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_virtual_machine.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_virtual_machine" {
-  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/virtualMachine.json"
+  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/virtualMachine.json"
 
   vm_size      = any //HardwareProfile.vmSize
   license_type = VirtualMachineProperties.licenseType

--- a/tools/apispec-rule-gen/mappings/azurerm_virtual_machine_data_disk_attachment.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_virtual_machine_data_disk_attachment.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_virtual_machine_data_disk_attachment" {
-  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/computeRPCommon.json"
+  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/computeRPCommon.json"
 
   lun                       = any //VirtualMachineScaleSetDataDisk.lun
   caching                   = Caching

--- a/tools/apispec-rule-gen/mappings/azurerm_virtual_machine_extension.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_virtual_machine_extension.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_virtual_machine_extension" {
-  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/virtualMachine.json"
+  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/virtualMachine.json"
 
   publisher                  = VirtualMachineExtensionProperties.publisher
   type                       = VirtualMachineExtensionProperties.type

--- a/tools/apispec-rule-gen/mappings/azurerm_virtual_machine_scale_set.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_virtual_machine_scale_set.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_virtual_machine_scale_set" {
-  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/computeRPCommon.json"
+  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/computeRPCommon.json"
 
   upgrade_policy_mode    = any //UpgradePolicy.mode
   eviction_policy        = evictionPolicy

--- a/tools/apispec-rule-gen/mappings/azurerm_virtual_machine_scale_set_extension.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_virtual_machine_scale_set_extension.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_virtual_machine_scale_set_extension" {
-  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/virtualMachineScaleSet.json"
+  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/virtualMachineScaleSet.json"
 
   publisher                  = VirtualMachineScaleSetExtensionProperties.publisher
   type                       = VirtualMachineScaleSetExtensionProperties.type

--- a/tools/apispec-rule-gen/mappings/azurerm_virtual_network.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_virtual_network.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_virtual_network" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/virtualNetwork.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualNetwork.json"
 
   dns_servers = DhcpOptions.dnsServers
 }

--- a/tools/apispec-rule-gen/mappings/azurerm_virtual_network_gateway.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_virtual_network_gateway.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_virtual_network_gateway" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/virtualNetworkGateway.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualNetworkGateway.json"
 
   type          = VirtualNetworkGatewayPropertiesFormat.gatewayType
   vpn_type      = VirtualNetworkGatewayPropertiesFormat.vpnType

--- a/tools/apispec-rule-gen/mappings/azurerm_virtual_network_gateway_connection.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_virtual_network_gateway_connection.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_virtual_network_gateway_connection" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/virtualNetworkGateway.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualNetworkGateway.json"
 
   type                               = VirtualNetworkGatewayConnectionType
   authorization_key                  = VirtualNetworkGatewayConnectionPropertiesFormat.authorizationKey

--- a/tools/apispec-rule-gen/mappings/azurerm_virtual_network_peering.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_virtual_network_peering.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_virtual_network_peering" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/virtualNetwork.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualNetwork.json"
 
   allow_virtual_network_access = VirtualNetworkPeeringPropertiesFormat.allowVirtualNetworkAccess
   allow_forwarded_traffic      = VirtualNetworkPeeringPropertiesFormat.allowForwardedTraffic

--- a/tools/apispec-rule-gen/mappings/azurerm_virtual_wan.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_virtual_wan.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_virtual_wan" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/virtualWan.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualWan.json"
 
   disable_vpn_encryption            = VirtualWanProperties.disableVpnEncryption
   allow_branch_to_branch_traffic    = VirtualWanProperties.allowBranchToBranchTraffic

--- a/tools/apispec-rule-gen/mappings/azurerm_vpn_gateway.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_vpn_gateway.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_vpn_gateway" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/virtualWan.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualWan.json"
 
   scale_unit = VpnGatewayProperties.vpnGatewayScaleUnit
 }

--- a/tools/apispec-rule-gen/mappings/azurerm_vpn_server_configuration.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_vpn_server_configuration.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_vpn_server_configuration" {
-  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-09-01/virtualWan.json"
+  import_path = "azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/virtualWan.json"
 
   vpn_authentication_types = VpnServerConfigurationProperties.vpnAuthenticationTypes
   vpn_protocols            = VpnServerConfigurationProperties.vpnProtocols

--- a/tools/apispec-rule-gen/mappings/azurerm_windows_virtual_machine.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_windows_virtual_machine.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_windows_virtual_machine" {
-  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/computeRPCommon.json"
+  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/computeRPCommon.json"
 
   admin_password             = any //OSProfile.adminPassword
   admin_username             = any //OSProfile.adminUsername

--- a/tools/apispec-rule-gen/mappings/azurerm_windows_virtual_machine_scale_set.hcl
+++ b/tools/apispec-rule-gen/mappings/azurerm_windows_virtual_machine_scale_set.hcl
@@ -1,5 +1,5 @@
 mapping "azurerm_windows_virtual_machine_scale_set" {
-  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/computeRPCommon.json"
+  import_path = "azure-rest-api-specs/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/computeRPCommon.json"
 
   admin_password                                    = any //VirtualMachineScaleSetOSProfile.adminPassword
   admin_username                                    = any //VirtualMachineScaleSetOSProfile.adminUsername


### PR DESCRIPTION
This PR updates Azure API versions in mapping files.

This change doesn't add or remove any rules, it just allows more enum values.
This change is based on v3.113.0.
https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v3.113.0