### PR TITLE
maintenance: Install terraform explicitly

### DIFF
--- a/.github/workflows/maintenance.yaml
+++ b/.github/workflows/maintenance.yaml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@v3
       - run: |
           cd tools/apispec-rule-gen/schema
           terraform init -upgrade


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-ruleset-azurerm/actions/runs/13801637258/job/38604999220

GitHub Actions Ubuntu-24.04 image no longer supports pre-installed Terraform.
See also https://github.com/actions/runner-images/issues/10636

This change explicitly install Terraform using the setup-terraform action, since the maintenance workflow that auto-generates the rules depends on it.