### PR TITLE
Remove hard-coded versions from integration tests

### DIFF
--- a/integration/basic/result.json.tmpl
+++ b/integration/basic/result.json.tmpl
@@ -4,7 +4,7 @@
       "rule": {
         "name": "azurerm_virtual_machine_invalid_vm_size",
         "severity": "error",
-        "link": "https://github.com/terraform-linters/tflint-ruleset-azurerm/blob/v0.27.0/docs/rules/azurerm_virtual_machine_invalid_vm_size.md"
+        "link": "https://github.com/terraform-linters/tflint-ruleset-azurerm/blob/v{{.Version}}/docs/rules/azurerm_virtual_machine_invalid_vm_size.md"
       },
       "message": "\"Standard_DS1_v3\" is an invalid value as vm_size",
       "range": {

--- a/integration/tags/result.json.tmpl
+++ b/integration/tags/result.json.tmpl
@@ -4,7 +4,7 @@
       "rule": {
         "name": "azurerm_resource_missing_tags",
         "severity": "info",
-        "link": "https://github.com/terraform-linters/tflint-ruleset-azurerm/blob/v0.27.0/docs/rules/azurerm_resource_missing_tags.md"
+        "link": "https://github.com/terraform-linters/tflint-ruleset-azurerm/blob/v{{.Version}}/docs/rules/azurerm_resource_missing_tags.md"
       },
       "message": "The resource is missing the following tags: \"Department\", \"Environment\".",
       "range": {
@@ -24,7 +24,7 @@
       "rule": {
         "name": "azurerm_resource_missing_tags",
         "severity": "info",
-        "link": "https://github.com/terraform-linters/tflint-ruleset-azurerm/blob/v0.27.0/docs/rules/azurerm_resource_missing_tags.md"
+        "link": "https://github.com/terraform-linters/tflint-ruleset-azurerm/blob/v{{.Version}}/docs/rules/azurerm_resource_missing_tags.md"
       },
       "message": "The resource is missing the following tags: \"Department\".",
       "range": {


### PR DESCRIPTION
Remove hard-coded versions from integration tests for release automation.
The `result.json.tmpl` file will be able to dynamically inject metadata using the `text/template` package.