### PR TITLE
Add tools/api-version-bumper

### DIFF
--- a/.github/workflows/maintenance.yaml
+++ b/.github/workflows/maintenance.yaml
@@ -1,8 +1,6 @@
 on:
-  push:
-    branches: [ master ]
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 1"
   workflow_dispatch: # Enables on-demand/manual triggering
 jobs:
   job:

--- a/.github/workflows/maintenance.yaml
+++ b/.github/workflows/maintenance.yaml
@@ -21,6 +21,7 @@ jobs:
           terraform providers schema -json > schema.json
           cd ../..
           git submodule update --remote
+          go run ./api-version-bumper
           go run ./apispec-rule-gen
       - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "tools/apispec-rule-gen/azure-rest-api-specs"]
 	path = tools/apispec-rule-gen/azure-rest-api-specs
 	url = https://github.com/Azure/azure-rest-api-specs
+[submodule "tools/api-version-bumper/terraform-provider-azurerm"]
+	path = tools/api-version-bumper/terraform-provider-azurerm
+	url = https://github.com/hashicorp/terraform-provider-azurerm

--- a/tools/README.md
+++ b/tools/README.md
@@ -55,3 +55,22 @@ $ terraform providers schema -json > schema.json
 $ cd ../../
 $ go run ./apispec-rule-gen
 ```
+
+## api-version-bumper
+
+This script parses the [terraform-provider-azurerm](https://github.com/hashicorp/terraform-provider-azurerm) codebase and updates the mapping files with the identified API versions. The repository has been added as a Git submodule and you will update the submodule version if you want to keep up with the latest.
+
+This tool is meant to be used together with apispec-rule-gen, and a typical workflow is to update API versions in mapping files and then generate rules with apispec-rule-gen.
+
+### Update terraform-provider-azurerm
+
+```console
+$ cd api-version-bumper/terraform-provider-azurerm
+$ git pull origin main
+$ cd ../../
+$ go run ./api-version-bumper
+```
+
+##  release
+
+This script automates the release process. Run `go run ./release` and follow the instructions to modify and commit the files required for releasing and push them to the remote. The actual build and publish process is triggerd by GitHub Actions and is not the responsibility of this script.

--- a/tools/api-version-bumper/main.go
+++ b/tools/api-version-bumper/main.go
@@ -1,0 +1,315 @@
+package main
+
+import (
+	"cmp"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/agext/levenshtein"
+)
+
+func main() {
+	// go run ./api-version-bumper <path-to-file>
+	if len(os.Args) == 2 {
+		processFile(os.Args[1])
+		return
+	}
+
+	// Find Terraform resource files
+	files, err := filepath.Glob("api-version-bumper/terraform-provider-azurerm/internal/services/*/*_resource.go")
+	if err != nil {
+		panic(err)
+	}
+
+	var errs []error
+	for _, file := range files {
+		// As an exception, the actual name of `user_assigned_identity_resource` is `*_resource_gen`, so replace the file name.
+		// https://github.com/hashicorp/terraform-provider-azurerm/tree/v4.23.0/internal/services/managedidentity
+		if strings.HasSuffix(file, "user_assigned_identity_resource.go") {
+			file = strings.ReplaceAll(file, "user_assigned_identity_resource.go", "user_assigned_identity_resource_gen.go")
+		}
+		if err := processFile(file); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if errs != nil {
+		fmt.Print("\n!!!!!!!!!! Failed to parse some files !!!!!!!!!!\n\n")
+		for _, err := range errs {
+			fmt.Println(err)
+		}
+	}
+}
+
+var apiVersionRE = regexp.MustCompile(`\d{4}-\d{2}-\d{2}(-preview)?`)
+
+func processFile(filePath string) error {
+	fmt.Printf("Processing %s ...\n", filePath)
+
+	resourceType := findResourceType(filePath)
+	apiVersion := findAPIVersion(filePath)
+
+	fmt.Printf("%s: %s\n", resourceType, apiVersion)
+
+	if resourceType == "" || apiVersion == "" {
+		return fmt.Errorf("path: %s\nresource type: %s\nAPI version: %s\n", filePath, resourceType, apiVersion)
+	}
+
+	mappingFile := fmt.Sprintf("apispec-rule-gen/mappings/%s.hcl", resourceType)
+	content, err := os.ReadFile(mappingFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		panic(err)
+	}
+	new := apiVersionRE.ReplaceAll(content, []byte(apiVersion))
+	if err := os.WriteFile(mappingFile, new, os.ModePerm); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func findResourceType(resourcePath string) string {
+	resourceType, resourceFunc := extractResourceTypeOrResourceFunc(resourcePath)
+	if resourceType != "" {
+		return resourceType
+	}
+
+	registrationPath := filepath.Join(filepath.Dir(resourcePath), "registration.go")
+	return extractResourceTypeFromResourceFunc(registrationPath, resourceFunc)
+}
+
+// Extract a resource type from `*_resource.go`.
+// If the resource type is not found, returns the name of a function
+// that will return the resource for further processing.
+func extractResourceTypeOrResourceFunc(resourcePath string) (resourceType string, resourceFunc string) {
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, resourcePath, nil, parser.ParseComments)
+	if err != nil {
+		panic(err)
+	}
+
+	ast.Inspect(node, func(n ast.Node) bool {
+		// A string literal beginning with "azurerm_" is likely a resource type.
+		if basicLit, ok := n.(*ast.BasicLit); ok {
+			str := strings.Trim(basicLit.Value, "\"")
+			if strings.HasPrefix(str, "azurerm_") {
+				resourceType = str
+			}
+		}
+
+		// Extract the function name that returns *pluginsdk.Resource.
+		// This function may be linked to the resource type in another file.
+		//
+		// e.g. `func resourceAnalysisServicesServer() *pluginsdk.Resource {`
+		if funcDecl, ok := n.(*ast.FuncDecl); ok {
+			if funcDecl.Type.Results != nil && len(funcDecl.Type.Results.List) == 1 {
+				if starExpr, ok := funcDecl.Type.Results.List[0].Type.(*ast.StarExpr); ok {
+					if selExpr, ok := starExpr.X.(*ast.SelectorExpr); ok {
+						if selExpr.Sel.Name == "Resource" {
+							resourceFunc = funcDecl.Name.Name
+						}
+					}
+				}
+			}
+		}
+
+		return true
+	})
+
+	return
+}
+
+// Extract a resource type from `registration.go`.
+// This file generally defines a map that links function names with resource types.
+func extractResourceTypeFromResourceFunc(registrationPath, resourceFunc string) string {
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, registrationPath, nil, parser.ParseComments)
+	if err != nil {
+		panic(err)
+	}
+
+	var resourceType string
+	ast.Inspect(node, func(n ast.Node) bool {
+		// In registration.go, a map is defined with the resource type as the key and the function call
+		// that returns the resource as the value, so we search for a key in KeyValueExpr
+		// whose value matches the resourceFunc.
+		//
+		// e.g.
+		//
+		// map[string]*pluginsdk.Resource{
+		// 	   "azurerm_analysis_services_server": resourceAnalysisServicesServer(),
+		// }
+		if kvExpr, ok := n.(*ast.KeyValueExpr); ok {
+			var key string
+			if basicLit, ok := kvExpr.Key.(*ast.BasicLit); ok {
+				key = strings.Trim(basicLit.Value, "\"")
+			}
+
+			if callExpr, ok := kvExpr.Value.(*ast.CallExpr); ok {
+				if ident, ok := callExpr.Fun.(*ast.Ident); ok {
+					if ident.Name == resourceFunc {
+						resourceType = key
+					}
+				}
+			}
+		}
+
+		// e.g. `resources["azurerm_security_center_auto_provisioning"] = resourceSecurityCenterAutoProvisioning()`
+		if assign, ok := n.(*ast.AssignStmt); ok {
+			var key string
+			if indexExpr, ok := assign.Lhs[0].(*ast.IndexExpr); ok {
+				if basicLit, ok := indexExpr.Index.(*ast.BasicLit); ok {
+					key = strings.Trim(basicLit.Value, "\"")
+				}
+			}
+
+			if callExpr, ok := assign.Rhs[0].(*ast.CallExpr); ok {
+				if ident, ok := callExpr.Fun.(*ast.Ident); ok {
+					if ident.Name == resourceFunc {
+						resourceType = key
+					}
+				}
+			}
+		}
+		return true
+	})
+
+	return resourceType
+}
+
+var exceptions = map[string]string{
+	"key_vault":            "2023-02-01", // https://github.com/hashicorp/terraform-provider-azurerm/blob/v4.23.0/internal/services/keyvault/key_vault_resource.go
+	"monitor_action_group": "2023-01-01", // https://github.com/hashicorp/terraform-provider-azurerm/blob/v4.23.0/internal/services/monitor/monitor_action_group_resource.go
+}
+
+func findAPIVersion(resourcePath string) string {
+	// Infers the name of the resource from the resource path.
+	// e.g. application_gateway_resource.go -> application_gateway
+	//
+	// Used to identify the most likely path among multiple import statements.
+	resource := strings.ReplaceAll(filepath.Base(resourcePath), "_resource.go", "")
+
+	// For some reason, some cases are not easily identifiable, so we apply a dictionary to them.
+	if apiVersion, ok := exceptions[resource]; ok {
+		return apiVersion
+	}
+
+	apiVersion := extractAPIVersion(resourcePath, resource)
+	if apiVersion != "" {
+		return apiVersion
+	}
+
+	// If the API version is not found in the resource path, it is likely in another file
+	// that handles client-related tasks, so we will try there.
+	files, err := filepath.Glob(fmt.Sprintf("%s/client/*.go", filepath.Dir(resourcePath)))
+	if err != nil {
+		panic(err)
+	}
+	for _, file := range files {
+		apiVersion = extractAPIVersion(file, resource)
+		if apiVersion != "" {
+			return apiVersion
+		}
+	}
+	return ""
+}
+
+// github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview/tenants
+var goAzureSDKRE = regexp.MustCompile(`github.com/hashicorp/go-azure-sdk/resource-manager/[^/]+/([^/]+)/([^/]+)`)
+
+// github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn
+var azureSDKForGoRE = regexp.MustCompile(`github.com/Azure/azure-sdk-for-go/services/[^/]+/mgmt/([^/]+)/([^/]+)`)
+
+// github.com/jackofallops/kermit/sdk/synapse/2019-06-01-preview/synapse
+var kermitSDKRE = regexp.MustCompile(`github.com/jackofallops/kermit/sdk/[^/]+/([^/]+)/([^/]+)`)
+
+type importSpec struct {
+	apiVersion string
+	resource   string
+}
+
+// Extract an API version from Go import statements by regexp.
+// If multiple import statements are found, the most likely path
+// is chosen by comparing it with the given resource name.
+func extractAPIVersion(path, resource string) string {
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+	if err != nil {
+		panic(err)
+	}
+
+	matches := []importSpec{}
+	for _, imp := range node.Imports {
+		importPath := strings.Trim(imp.Path.Value, "\"")
+		if match := goAzureSDKRE.FindStringSubmatch(importPath); match != nil {
+			matches = append(matches, importSpec{apiVersion: match[1], resource: match[2]})
+		}
+		if match := azureSDKForGoRE.FindStringSubmatch(importPath); match != nil {
+			matches = append(matches, importSpec{apiVersion: match[1], resource: match[2]})
+		}
+		if match := kermitSDKRE.FindStringSubmatch(importPath); match != nil {
+			matches = append(matches, importSpec{apiVersion: match[1], resource: match[2]})
+		}
+	}
+
+	if len(matches) > 0 {
+		// Pattern 1: Calculate the Longest common subsequence (LCS) of two strings.
+		// If there is only one path that matches with at least 4 characters, use that.
+		longMatches := []importSpec{}
+		for _, match := range matches {
+			if len(longestCommonSubstring(match.resource, resource)) > 3 {
+				longMatches = append(longMatches, match)
+			}
+		}
+		if len(longMatches) == 1 {
+			return longMatches[0].apiVersion
+		}
+		// Pattern 2: Calculate the Levenshtein distance between two characters and use the smaller one.
+		spec := slices.MinFunc(matches, func(a, b importSpec) int {
+			as := levenshtein.Distance(a.resource, resource, nil)
+			bs := levenshtein.Distance(b.resource, resource, nil)
+			return cmp.Compare(as, bs)
+		})
+		return spec.apiVersion
+	}
+	return ""
+}
+
+func longestCommonSubstring(str1, str2 string) string {
+	len1 := len(str1)
+	len2 := len(str2)
+
+	dp := make([][]int, len1+1)
+	for i := range dp {
+		dp[i] = make([]int, len2+1)
+	}
+
+	maxLength := 0
+	endPosition := 0
+
+	for i := 1; i <= len1; i++ {
+		for j := 1; j <= len2; j++ {
+			if str1[i-1] == str2[j-1] {
+				dp[i][j] = dp[i-1][j-1] + 1
+				if dp[i][j] > maxLength {
+					maxLength = dp[i][j]
+					endPosition = i
+				}
+			}
+		}
+	}
+
+	if maxLength == 0 {
+		return ""
+	}
+	return str1[endPosition-maxLength : endPosition]
+}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,7 +1,9 @@
 module github.com/terraform-linters/tflint-ruleset-azurerm/tools
 
 go 1.24.1
+
 require (
+	github.com/agext/levenshtein v1.2.3
 	github.com/google/go-github/v69 v69.2.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl/v2 v2.23.0
@@ -10,7 +12,6 @@ require (
 )
 
 require (
-	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,5 +1,5 @@
-github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
-github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
+github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
This PR introduces a new internal tool called api-version-bumper. This tool is intended to automate the task of updating API versions such as https://github.com/terraform-linters/tflint-ruleset-azurerm/pull/345.

The api-version-bumper parses the terraform-provider-azurerm codebase to identify Terraform resources and Azure API versions, and updates the API versions in the mapping files accordingly.