### PR TITLE
Remove unneeded repository info from goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,8 +42,6 @@ signs:
       - --yes
 release:
   github:
-    owner: terraform-linters
-    name: tflint-ruleset-azurerm
   draft: true
 snapshot:
   version_template: "{{ .Tag }}-dev"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-linters/tflint-ruleset-azurerm
 
-go 1.24.1
+go 1.24.5
 
 require (
 	github.com/dave/dst v0.27.3


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-ruleset-opa/pull/167