### PR TITLE
Fix E2E tests to take into account the newly added JSON fields

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -20,6 +20,23 @@ type meta struct {
 	Version string
 }
 
+type result struct {
+	Issues []issue `json:"issues"`
+	Errors []any   `json:"errors"`
+}
+
+type issue struct {
+	Rule    any `json:"rule"`
+	Message any `json:"message"`
+	Range   any `json:"range"`
+	Callers any `json:"callers"`
+
+	// The following fields are ignored because they are added in TFLint v0.59.1.
+	// We can uncomment this once the minimum supported version is v0.59.1+.
+	// Fixed   any `json:"fixed"`
+	// Fixable any `json:"fixable"`
+}
+
 func TestIntegration(t *testing.T) {
 	cases := []struct {
 		Name    string
@@ -57,12 +74,12 @@ func TestIntegration(t *testing.T) {
 			t.Fatalf("Failed `%s`: %s", tc.Name, err)
 		}
 
-		var expected interface{}
+		var expected result
 		if err := json.Unmarshal(ret, &expected); err != nil {
 			t.Fatalf("Failed `%s`: %s", tc.Name, err)
 		}
 
-		var got interface{}
+		var got result
 		if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 			t.Fatalf("Failed `%s`: %s", tc.Name, err)
 		}


### PR DESCRIPTION
The `fix` and `fixable` are added in v0.59.1.
https://github.com/terraform-linters/tflint/pull/2355