### PR TITLE
Drop support for Cosign signatures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
       uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
         go-version-file: 'go.mod'
-    - name: Install Cosign
-      uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
       with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,18 +28,6 @@ checksum:
   name_template: 'checksums.txt'
   extra_files:
     - glob: ./dist/raw/*
-signs:
-  - cmd: cosign
-    signature: '${artifact}.keyless.sig'
-    certificate: '${artifact}.pem'
-    output: true
-    artifacts: checksum
-    args:
-      - sign-blob
-      - '--output-certificate=${certificate}'
-      - '--output-signature=${signature}'
-      - '${artifact}'
-      - --yes
 release:
   github:
   draft: true


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint-ruleset-azurerm/pull/217 https://github.com/terraform-linters/tflint-ruleset-azurerm/pull/335

We initially introduced Cosign for keyless verification, but now we use GitHub Artifact Attestations.
We are now dropping support for it due to breaking changes introduced with the release of Cosign v3.