### PR TITLE
ci: user_assigned_identity_resource exception is not needed anymore since submodule commit f12a154

### DIFF
--- a/tools/api-version-bumper/main.go
+++ b/tools/api-version-bumper/main.go
@@ -30,11 +30,6 @@ func main() {
 
 	var errs []error
 	for _, file := range files {
-		// As an exception, the actual name of `user_assigned_identity_resource` is `*_resource_gen`, so replace the file name.
-		// https://github.com/hashicorp/terraform-provider-azurerm/tree/v4.23.0/internal/services/managedidentity
-		if strings.HasSuffix(file, "user_assigned_identity_resource.go") {
-			file = strings.ReplaceAll(file, "user_assigned_identity_resource.go", "user_assigned_identity_resource_gen.go")
-		}
 		if err := processFile(file); err != nil {
 			errs = append(errs, err)
 		}


### PR DESCRIPTION
[user_assigned_identity_resource_gen.go](https://github.com/hashicorp/terraform-provider-azurerm/commit/f12a154954252a111830086123f3796870b60f8e#diff-28e73d0dbcaa875b48037df1af3f564eb9212a966bea5a586484db4899e6edb1) does not exist anymore. Instead the logic was moved into `internal/services/managedidentity/user_assigned_identity_resource.go`

Will fix #449 