### PR TITLE
fix: fixes the issue #467 by setting expand mode to none in AppServiceAppInsightsHiddenLinkRule

### DIFF
--- a/rules/azurerm_app_service_app_insights_hidden_link.go
+++ b/rules/azurerm_app_service_app_insights_hidden_link.go
@@ -85,7 +85,7 @@ func (r *AzurermAppServiceAppInsightsHiddenLinkRule) checkResourceType(runner tf
 				},
 			},
 			{
-				Type: "site_config",
+				Type: appServiceSiteConfigAttrName,
 				Body: &hclext.BodySchema{
 					Attributes: []hclext.AttributeSchema{
 						{Name: appServiceSiteConfigAppInsightsConnectionKey},
@@ -94,7 +94,9 @@ func (r *AzurermAppServiceAppInsightsHiddenLinkRule) checkResourceType(runner tf
 				},
 			},
 		},
-	}, nil)
+	}, &tflint.GetModuleContentOption{
+		ExpandMode: tflint.ExpandModeNone,
+	})
 
 	if err != nil {
 		return err
@@ -126,7 +128,7 @@ func (r *AzurermAppServiceAppInsightsHiddenLinkRule) checkResourceType(runner tf
 		// Check in site_config block
 		if !hasAppInsights {
 			for _, block := range resource.Body.Blocks {
-				if block.Type == "site_config" {
+				if block.Type == appServiceSiteConfigAttrName {
 					// Check for application_insights_connection_string
 					if attr, exists := block.Body.Attributes[appServiceSiteConfigAppInsightsConnectionKey]; exists {
 						err := runner.EvaluateExpr(attr.Expr, func(val string) error {


### PR DESCRIPTION
fixes bug introduced in #430.  From the conversation on that PR I implemented the change from https://github.com/terraform-linters/tflint/issues/2431 which forces no expansion of the ignore_changes attributes as they're handled differently than normal blocks.

Without this fix I was getting the same error mentioned in that issue, and with the change the rule works as intended.

fixes issue #467 