### PR TITLE
fix(rule generator): handle also CRLF instead of just LF

### DIFF
--- a/rules/generator/main.go
+++ b/rules/generator/main.go
@@ -26,7 +26,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	ruleName = strings.Trim(ruleName, "\n")
+	ruleName = strings.TrimSpace(ruleName)
 
 	meta := &metadata{RuleNameCC: toCamelCase(ruleName), RuleName: ruleName}
 


### PR DESCRIPTION
Fixes issue #485 with the Rule Generator on Windows.