### PR TITLE
Added Retired Virtual Machine Size Rules for Linux and Windows VMs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ This documentation describes a list of rules available by enabling this ruleset.
 |[azurerm_windows_virtual_machine_invalid_size](rules/azurerm_windows_virtual_machine_invalid_size.md)|✔|
 |[azurerm_windows_virtual_machine_scale_set_invalid_sku](rules/azurerm_windows_virtual_machine_scale_set_invalid_sku.md)|✔|
 |[azurerm_linux_virtual_machine_retried_size](rules/azurerm_linux_virtual_machine_retried_size.md)|✔|
+|[azurerm_windows_virtual_machine_retried_size](rules/azurerm_windows_virtual_machine_retried_size.md)|✔|
 
 ## API Specification Rules
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ This documentation describes a list of rules available by enabling this ruleset.
 |[azurerm_windows_virtual_machine_invalid_name](rules/azurerm_windows_virtual_machine_invalid_name.md)|✔|
 |[azurerm_windows_virtual_machine_invalid_size](rules/azurerm_windows_virtual_machine_invalid_size.md)|✔|
 |[azurerm_windows_virtual_machine_scale_set_invalid_sku](rules/azurerm_windows_virtual_machine_scale_set_invalid_sku.md)|✔|
+|[azurerm_linux_virtual_machine_retried_size](rules/azurerm_linux_virtual_machine_retried_size.md)|✔|
 
 ## API Specification Rules
 

--- a/docs/rules/azurerm_linux_virtual_machine_retired_size.md
+++ b/docs/rules/azurerm_linux_virtual_machine_retired_size.md
@@ -1,0 +1,58 @@
+# azurerm_linux_virtual_machine_retired_size
+
+Warns about size values that are retired or announced-for-retirement based on https://learn.microsoft.com/azure/virtual-machines/sizes/retirement/retired-sizes-list
+
+Values that produce a warning are:
+
+- Standard_B1ms
+- Standard_B2ms
+- Standard_B1s
+- Standard_B2s
+- Standard_D1_v2
+- Standard_D2_v2
+- Standard_D3_v2
+- Standard_DS1_v2
+- Standard_DS2_v2
+- Standard_F1
+- Standard_F2
+- Standard_FS2
+- Standard_F2s_v2
+- Standard_G1
+- Standard_G2
+- Standard_GS1
+- Standard_NC6_v3
+- Standard_NC12_v3
+- Standard_NC24_v3
+
+## Example
+
+```hcl
+resource "azurerm_linux_virtual_machine" "foo" {
+  size = "Standard_B1ms"
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Notice: "Standard_B1ms" is a retired VM size and may no longer available (azurerm_linux_virtual_machine_retired_size)
+
+  on template.tf line 2:
+  2:   size = "Standard_B1ms"
+
+Reference: https://github.com/terraform-linters/tflint-ruleset-azurerm/blob/v0.32.0/docs/rules/azurerm_linux_virtual_machine_retired_size.md
+
+```
+
+## Why
+
+Linux Virtual Machines configured to use these sizes may retrun an error when calling the API by `terraform apply`.
+
+## How To Fix
+
+Update the Virtual Machine size to a supports size.
+
+## Source
+
+https://learn.microsoft.com/en-gb/azure/virtual-machines/sizes/retirement/retired-sizes-list

--- a/docs/rules/azurerm_windows_virtual_machine_retired_size.md
+++ b/docs/rules/azurerm_windows_virtual_machine_retired_size.md
@@ -1,4 +1,4 @@
-# azurerm_linux_virtual_machine_retired_size
+# azurerm_windows_virtual_machine_retired_size
 
 Warns about size values that are retired or announced-for-retirement based on https://learn.microsoft.com/azure/virtual-machines/sizes/retirement/retired-sizes-list
 
@@ -27,7 +27,7 @@ Values that produce a warning are:
 ## Example
 
 ```hcl
-resource "azurerm_linux_virtual_machine" "foo" {
+resource "azurerm_windows_virtual_machine" "foo" {
   size = "Standard_B1ms"
 }
 ```
@@ -36,18 +36,18 @@ resource "azurerm_linux_virtual_machine" "foo" {
 $ tflint
 1 issue(s) found:
 
-Notice: "Standard_B1ms" is a retired VM size and may no longer available (azurerm_linux_virtual_machine_retired_size)
+Notice: "Standard_B1ms" is a retired VM size and may no longer available (azurerm_windows_virtual_machine_retired_size)
 
   on template.tf line 2:
   2:   size = "Standard_B1ms"
 
-Reference: https://github.com/terraform-linters/tflint-ruleset-azurerm/blob/v0.32.0/docs/rules/azurerm_linux_virtual_machine_retired_size.md
+Reference: https://github.com/terraform-linters/tflint-ruleset-azurerm/blob/v0.32.0/docs/rules/azurerm_windows_virtual_machine_retired_size.md
 
 ```
 
 ## Why
 
-Linux Virtual Machines configured to use these sizes may return an error when calling the API by `terraform apply`.
+Windows Virtual Machines configured to use these sizes may return an error when calling the API by `terraform apply`.
 
 ## How To Fix
 

--- a/rules/azurerm_linux_virtual_machine_retired_size.go
+++ b/rules/azurerm_linux_virtual_machine_retired_size.go
@@ -1,0 +1,86 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-azurerm/project"
+)
+
+// AzurermLinuxVirtualMachineRetiredSizeRule checks that Linux Virtual Machine is not configured to use a retired Virtual Machine size.
+type AzurermLinuxVirtualMachineRetiredSizeRule struct {
+	tflint.DefaultRule
+
+	resourceType  string
+	attributeName string
+}
+
+// NewAzurermLinuxVirtualMachineRetiredSizeRule returns new rule with default attributes
+func NewAzurermLinuxVirtualMachineRetiredSizeRule() *AzurermLinuxVirtualMachineRetiredSizeRule {
+	return &AzurermLinuxVirtualMachineRetiredSizeRule{
+		resourceType:  "azurerm_linux_virtual_machine",
+		attributeName: "size",
+	}
+}
+
+// Name returns the rule name
+func (r *AzurermLinuxVirtualMachineRetiredSizeRule) Name() string {
+	return "azurerm_linux_virtual_machine_retired_size"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AzurermLinuxVirtualMachineRetiredSizeRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AzurermLinuxVirtualMachineRetiredSizeRule) Severity() tflint.Severity {
+	return tflint.NOTICE
+}
+
+// Link returns the rule reference link
+func (r *AzurermLinuxVirtualMachineRetiredSizeRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks that the azurerm_linux_virtual_machine.size is not configured to use a retried Virtual Machine size.
+func (r *AzurermLinuxVirtualMachineRetiredSizeRule) Check(runner tflint.Runner) error {
+	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
+		Attributes: []hclext.AttributeSchema{
+			{Name: r.attributeName},
+		},
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Blocks {
+		attribute, exists := resource.Body.Attributes[r.attributeName]
+		if !exists {
+			continue
+		}
+
+		err := runner.EvaluateExpr(attribute.Expr, func(val string) error {
+			found := false
+			for _, item := range retiredMachineSizes {
+				if item == val {
+					found = true
+				}
+			}
+			if found {
+				runner.EmitIssue(
+					r,
+					fmt.Sprintf(`"%s" is a retired or announced-for-retirement Virtual Machine Size`, val),
+					attribute.Expr.Range(),
+				)
+			}
+			return nil
+		}, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/rules/azurerm_linux_virtual_machine_retired_size_test.go
+++ b/rules/azurerm_linux_virtual_machine_retired_size_test.go
@@ -23,11 +23,11 @@ resource "azurerm_linux_virtual_machine" "example" {
 			Expected: helper.Issues{
 				{
 					Rule:    NewAzurermLinuxVirtualMachineRetiredSizeRule(),
-					Message: `"Standard_B1ms" is a retired VM size and is no longer available`,
+					Message: `"Standard_B1ms" is a retired or announced-for-retirement Virtual Machine Size`,
 					Range: hcl.Range{
 						Filename: "resource.tf",
 						Start:    hcl.Pos{Line: 3, Column: 10},
-						End:      hcl.Pos{Line: 3, Column: 26},
+						End:      hcl.Pos{Line: 3, Column: 25},
 					},
 				},
 			},

--- a/rules/azurerm_linux_virtual_machine_retired_size_test.go
+++ b/rules/azurerm_linux_virtual_machine_retired_size_test.go
@@ -1,0 +1,59 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AzurermLinuxVirtualMachineRetiredSize(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "retired size emits issue",
+			Content: `
+resource "azurerm_linux_virtual_machine" "example" {
+  size = "Standard_B1ms"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAzurermLinuxVirtualMachineRetiredSizeRule(),
+					Message: `"Standard_B1ms" is a retired VM size and is no longer available`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 10},
+						End:      hcl.Pos{Line: 3, Column: 26},
+					},
+				},
+			},
+		},
+		{
+			Name: "valid size emits no issue",
+			Content: `
+resource "azurerm_linux_virtual_machine" "example" {
+  size = "Standard_D4s_v5"
+}
+`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAzurermLinuxVirtualMachineRetiredSizeRule()
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			helper.AssertIssues(t, tc.Expected, runner.Issues)
+		})
+	}
+}

--- a/rules/azurerm_windows_virtual_machine_retired_size.go
+++ b/rules/azurerm_windows_virtual_machine_retired_size.go
@@ -1,0 +1,86 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-azurerm/project"
+)
+
+// AzurermWindowsVirtualMachineRetiredSizeRule checks that Windows Virtual Machine is not configured to use a retired Virtual Machine size.
+type AzurermWindowsVirtualMachineRetiredSizeRule struct {
+	tflint.DefaultRule
+
+	resourceType  string
+	attributeName string
+}
+
+// NewAzurermWindowsVirtualMachineRetiredSizeRule returns new rule with default attributes
+func NewAzurermWindowsVirtualMachineRetiredSizeRule() *AzurermWindowsVirtualMachineRetiredSizeRule {
+	return &AzurermWindowsVirtualMachineRetiredSizeRule{
+		resourceType:  "azurerm_windows_virtual_machine",
+		attributeName: "size",
+	}
+}
+
+// Name returns the rule name
+func (r *AzurermWindowsVirtualMachineRetiredSizeRule) Name() string {
+	return "azurerm_windows_virtual_machine_retired_size"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AzurermWindowsVirtualMachineRetiredSizeRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AzurermWindowsVirtualMachineRetiredSizeRule) Severity() tflint.Severity {
+	return tflint.NOTICE
+}
+
+// Link returns the rule reference link
+func (r *AzurermWindowsVirtualMachineRetiredSizeRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks that the azurerm_windows_virtual_machine.size is not configured to use a retried Virtual Machine size.
+func (r *AzurermWindowsVirtualMachineRetiredSizeRule) Check(runner tflint.Runner) error {
+	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
+		Attributes: []hclext.AttributeSchema{
+			{Name: r.attributeName},
+		},
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Blocks {
+		attribute, exists := resource.Body.Attributes[r.attributeName]
+		if !exists {
+			continue
+		}
+
+		err := runner.EvaluateExpr(attribute.Expr, func(val string) error {
+			found := false
+			for _, item := range retiredMachineSizes {
+				if item == val {
+					found = true
+				}
+			}
+			if found {
+				runner.EmitIssue(
+					r,
+					fmt.Sprintf(`"%s" is a retired or announced-for-retirement Virtual Machine Size`, val),
+					attribute.Expr.Range(),
+				)
+			}
+			return nil
+		}, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/rules/azurerm_windows_virtual_machine_retired_size_test.go
+++ b/rules/azurerm_windows_virtual_machine_retired_size_test.go
@@ -1,0 +1,59 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AzurermWindowsVirtualMachineRetiredSize(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "retired size emits issue",
+			Content: `
+resource "azurerm_windows_virtual_machine" "example" {
+  size = "Standard_B1ms"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAzurermWindowsVirtualMachineRetiredSizeRule(),
+					Message: `"Standard_B1ms" is a retired or announced-for-retirement Virtual Machine Size`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 10},
+						End:      hcl.Pos{Line: 3, Column: 25},
+					},
+				},
+			},
+		},
+		{
+			Name: "valid size emits no issue",
+			Content: `
+resource "azurerm_windows_virtual_machine" "example" {
+  size = "Standard_D4s_v5"
+}
+`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAzurermWindowsVirtualMachineRetiredSizeRule()
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			helper.AssertIssues(t, tc.Expected, runner.Issues)
+		})
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -20,4 +20,5 @@ var Rules = append([]tflint.Rule{
 	NewAzurermResourceMissingTagsRule(),
 	NewAzurermResourcesMissingPreventDestroyRule(),
 	NewAzurermLinuxVirtualMachineInvalidNameRule(),
+	NewAzurermLinuxVirtualMachineRetiredSizeRule(),
 }, apispec.Rules...)

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -21,4 +21,5 @@ var Rules = append([]tflint.Rule{
 	NewAzurermResourcesMissingPreventDestroyRule(),
 	NewAzurermLinuxVirtualMachineInvalidNameRule(),
 	NewAzurermLinuxVirtualMachineRetiredSizeRule(),
+	NewAzurermWindowsVirtualMachineRetiredSizeRule(),
 }, apispec.Rules...)

--- a/rules/utils.go
+++ b/rules/utils.go
@@ -1452,3 +1452,25 @@ var validMachineSizes = []string{
 	"Standard_NV8as_v4",
 	"Standard_PB6s",
 }
+
+var retiredMachineSizes = []string{
+	"Standard_B1ms",
+	"Standard_B2ms",
+	"Standard_B1s",
+	"Standard_B2s",
+	"Standard_D1_v2",
+	"Standard_D2_v2",
+	"Standard_D3_v2",
+	"Standard_DS1_v2",
+	"Standard_DS2_v2",
+	"Standard_F1",
+	"Standard_F2",
+	"Standard_FS2",
+	"Standard_F2s_v2",
+	"Standard_G1",
+	"Standard_G2",
+	"Standard_GS1",
+	"Standard_NC6_v3",
+	"Standard_NC12_v3",
+	"Standard_NC24_v3",
+}

--- a/tools/apispec-rule-gen/doc_README.md.tmpl
+++ b/tools/apispec-rule-gen/doc_README.md.tmpl
@@ -18,6 +18,7 @@ This documentation describes a list of rules available by enabling this ruleset.
 |[azurerm_windows_virtual_machine_invalid_size](rules/azurerm_windows_virtual_machine_invalid_size.md)|✔|
 |[azurerm_windows_virtual_machine_scale_set_invalid_sku](rules/azurerm_windows_virtual_machine_scale_set_invalid_sku.md)|✔|
 |[azurerm_linux_virtual_machine_retried_size](rules/azurerm_linux_virtual_machine_retried_size.md)|✔|
+|[azurerm_windows_virtual_machine_retried_size](rules/azurerm_windows_virtual_machine_retried_size.md)|✔|
 
 ## API Specification Rules
 

--- a/tools/apispec-rule-gen/doc_README.md.tmpl
+++ b/tools/apispec-rule-gen/doc_README.md.tmpl
@@ -17,6 +17,7 @@ This documentation describes a list of rules available by enabling this ruleset.
 |[azurerm_windows_virtual_machine_invalid_name](rules/azurerm_windows_virtual_machine_invalid_name.md)|✔|
 |[azurerm_windows_virtual_machine_invalid_size](rules/azurerm_windows_virtual_machine_invalid_size.md)|✔|
 |[azurerm_windows_virtual_machine_scale_set_invalid_sku](rules/azurerm_windows_virtual_machine_scale_set_invalid_sku.md)|✔|
+|[azurerm_linux_virtual_machine_retried_size](rules/azurerm_linux_virtual_machine_retried_size.md)|✔|
 
 ## API Specification Rules
 


### PR DESCRIPTION
This pull request introduces a new rule to detect the use of retired Virtual Machine sizes for Linux Virtual Machines.