### PR TITLE
Update Rule azurerm_public_ip_invalid_sku

### DIFF
--- a/docs/rules/azurerm_public_ip_invalid_sku.md
+++ b/docs/rules/azurerm_public_ip_invalid_sku.md
@@ -7,6 +7,7 @@ Warns about values that appear to be invalid based on [azure-rest-api-specs](htt
 Allowed values are:
 - Basic
 - Standard
+- StandardV2
 
 ## Example
 

--- a/rules/apispec/azurerm_public_ip_invalid_sku.go
+++ b/rules/apispec/azurerm_public_ip_invalid_sku.go
@@ -27,7 +27,7 @@ func NewAzurermPublicIPInvalidSkuRule() *AzurermPublicIPInvalidSkuRule {
 		enum: []string{
 			"Basic",
 			"Standard",
-			"StandardV2
+			"StandardV2,
 		},
 	}
 }

--- a/rules/apispec/azurerm_public_ip_invalid_sku.go
+++ b/rules/apispec/azurerm_public_ip_invalid_sku.go
@@ -27,6 +27,7 @@ func NewAzurermPublicIPInvalidSkuRule() *AzurermPublicIPInvalidSkuRule {
 		enum: []string{
 			"Basic",
 			"Standard",
+			"StandardV2
 		},
 	}
 }

--- a/rules/apispec/azurerm_public_ip_invalid_sku.go
+++ b/rules/apispec/azurerm_public_ip_invalid_sku.go
@@ -27,7 +27,7 @@ func NewAzurermPublicIPInvalidSkuRule() *AzurermPublicIPInvalidSkuRule {
 		enum: []string{
 			"Basic",
 			"Standard",
-			"StandardV2,
+			"StandardV2",
 		},
 	}
 }


### PR DESCRIPTION
This is a new SKU for Public IP addresses used by the new StandardV2 NAT Gateways.