### PR TITLE
github: Use setup-tflint instead of install scripts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,8 +21,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         version: [v0.46.0, latest]
-    env:
-      TFLINT_VERSION: ${{ matrix.version }}
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -31,9 +29,9 @@ jobs:
       with:
         go-version-file: 'go.mod'
     - name: Install TFLint
-      run: curl -sL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: terraform-linters/setup-tflint@1cf010d3c7aef302051ccdb68c14c5dc2efa34ef # v6.3.1
+      with:
+        tflint_version: ${{ matrix.version }}
     - name: Install plugin (Linux)
       if: runner.os == 'Linux'
       run: make install


### PR DESCRIPTION
Follow up of https://github.com/terraform-linters/tflint/pull/2607